### PR TITLE
Add some basic modules

### DIFF
--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -16,14 +16,14 @@ package executor
 // TiOpsExecutor is the executor interface for TiOps, all tasks will in the end
 // be passed to a executor and then be actually performed.
 type TiOpsExecutor interface {
-	// Init builds and initializes an executor
-	Init(config interface{}) error
+	// Initialize builds and initializes an executor
+	Initialize(config interface{}) error
 
-	// Exec run the command, then return it's stdout and stderr
+	// Execute run the command, then return it's stdout and stderr
 	// NOTE: stdin is not supported as it seems we don't need it (for now). If
 	// at some point in the future we need to pass stdin to a command, we'll
 	// need to refactor this function and its implementations.
-	Exec(cmd string, sudo bool) (stdout []byte, stderr []byte, err error)
+	Execute(cmd string, sudo bool) (stdout []byte, stderr []byte, err error)
 
 	// Transfer copies files from or to a target
 	Transfer(src string, dst string) error

--- a/pkg/executor/ssh.go
+++ b/pkg/executor/ssh.go
@@ -58,11 +58,11 @@ func (sshExec *SSHExecutor) Initialize(config SSHConfig) error {
 	return nil
 }
 
-// Execute run the command via SSH
+// Execute run the command via SSH, it's not invoking any specific shell by default.
 func (sshExec *SSHExecutor) Execute(cmd string, sudo bool) ([]byte, []byte, error) {
 	// try to acquire root permission
 	if sudo {
-		cmd = fmt.Sprintf("/bin/bash -c 'sudo -H -u root %s'", cmd)
+		cmd = fmt.Sprintf("sudo -H -u root %s", cmd)
 	}
 
 	// run command on remote host

--- a/pkg/executor/ssh.go
+++ b/pkg/executor/ssh.go
@@ -37,8 +37,8 @@ type (
 	}
 )
 
-// Init builds and initializes a SSHExecutor
-func (sshExec *SSHExecutor) Init(config SSHConfig) error {
+// Initialize builds and initializes a SSHExecutor
+func (sshExec *SSHExecutor) Initialize(config SSHConfig) error {
 	// build easyssh config
 	sshExec.Config = &easyssh.MakeConfig{
 		Server:  config.Host,
@@ -58,8 +58,8 @@ func (sshExec *SSHExecutor) Init(config SSHConfig) error {
 	return nil
 }
 
-// Exec run the command via SSH
-func (sshExec *SSHExecutor) Exec(cmd string, sudo bool) ([]byte, []byte, error) {
+// Execute run the command via SSH
+func (sshExec *SSHExecutor) Execute(cmd string, sudo bool) ([]byte, []byte, error) {
 	// try to acquire root permission
 	if sudo {
 		cmd = fmt.Sprintf("/bin/bash -c 'sudo -H -u root %s'", cmd)

--- a/pkg/module/shell.go
+++ b/pkg/module/shell.go
@@ -1,0 +1,65 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package module
+
+import (
+	"fmt"
+
+	"github.com/pingcap-incubator/tiops/pkg/executor"
+)
+
+const (
+	defaultShell = "/bin/bash"
+)
+
+// ShellModuleConfig is the configurations used to initialize a TiOpsModuleSystemd
+type ShellModuleConfig struct {
+	Command  string // the command to run
+	Sudo     bool   // whether use root priviledge to run the command
+	Chdir    string // change working directory before running the command
+	UseShell bool   // whether use shell to invoke the command
+}
+
+// ShellModule is the module used to control systemd units
+type ShellModule struct {
+	cmd  string // the built command
+	sudo bool
+}
+
+// NewShellModule builds and returns a TiOpsModuleSystemd object base on
+// given config.
+func NewShellModule(config ShellModuleConfig) *ShellModule {
+	cmd := config.Command
+
+	if len(config.Chdir) > 0 {
+		cmd = fmt.Sprintf("cd %s && %s",
+			config.Chdir, cmd)
+	}
+
+	if config.UseShell {
+		cmd = fmt.Sprintf("%s -c '%s'",
+			defaultShell, cmd)
+	}
+
+	return &ShellModule{
+		cmd:  cmd,
+		sudo: config.Sudo,
+	}
+}
+
+// Execute passes the command to executor and returns its results, the executor
+// should be already initialized.
+func (mod *ShellModule) Execute(exec executor.TiOpsExecutor) ([]byte, []byte, error) {
+	return exec.Execute(mod.cmd, mod.sudo)
+}

--- a/pkg/module/shell.go
+++ b/pkg/module/shell.go
@@ -33,12 +33,11 @@ type ShellModule struct {
 	sudo bool
 }
 
-// NewShellModule builds and returns a TiOpsModuleSystemd object base on
-// given config.
+// NewShellModule builds and returns a ShellModule object base on given config.
 func NewShellModule(config ShellModuleConfig) *ShellModule {
 	cmd := config.Command
 
-	if len(config.Chdir) > 0 {
+	if config.Chdir != "" {
 		cmd = fmt.Sprintf("cd %s && %s",
 			config.Chdir, cmd)
 	}

--- a/pkg/module/shell.go
+++ b/pkg/module/shell.go
@@ -19,10 +19,6 @@ import (
 	"github.com/pingcap-incubator/tiops/pkg/executor"
 )
 
-const (
-	defaultShell = "/bin/bash"
-)
-
 // ShellModuleConfig is the configurations used to initialize a TiOpsModuleSystemd
 type ShellModuleConfig struct {
 	Command  string // the command to run

--- a/pkg/module/systemd.go
+++ b/pkg/module/systemd.go
@@ -1,0 +1,67 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package module
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/pingcap-incubator/tiops/pkg/executor"
+)
+
+// TiOpsModuleSystemdConfig is the configurations used to initialize a TiOpsModuleSystemd
+type TiOpsModuleSystemdConfig struct {
+	Unit         string // the name of systemd unit(s)
+	Action       string // the action to perform with the unit
+	Enabled      bool   // enable the unit or not
+	ReloadDaemon bool   // Run daemon-reload before other actions
+
+	// TODO: support more systemd functionalities
+	//Scope string // user or system
+	//Force bool // add the `--force` arg to systemctl command
+}
+
+// TiOpsModuleSystemd is the module used to control systemd units
+type TiOpsModuleSystemd struct {
+	cmd string // the built command
+}
+
+// NewTiOpsModuleSystemd builds and returns a TiOpsModuleSystemd object base on
+// given config.
+func NewTiOpsModuleSystemd(config TiOpsModuleSystemdConfig) *TiOpsModuleSystemd {
+	systemctl := "/usr/bin/systemctl" // TODO: find binary in $PATH
+
+	cmd := fmt.Sprintf("%s %s %s",
+		systemctl, strings.ToLower(config.Action), config.Unit)
+
+	if config.Enabled {
+		cmd = fmt.Sprintf("%s && %s enable %s",
+			cmd, systemctl, config.Unit)
+	}
+
+	if config.ReloadDaemon {
+		cmd = fmt.Sprintf("%s daemon-reload && %s",
+			systemctl, cmd)
+	}
+
+	return &TiOpsModuleSystemd{
+		cmd: cmd,
+	}
+}
+
+// Execute passes the command to executor and returns its results, the executor
+// should be already initialized.
+func (mod *TiOpsModuleSystemd) Execute(exec executor.TiOpsExecutor) ([]byte, []byte, error) {
+	return exec.Execute(mod.cmd, true)
+}

--- a/pkg/module/systemd.go
+++ b/pkg/module/systemd.go
@@ -32,8 +32,8 @@ type SystemdModuleConfig struct {
 	Unit         string // the name of systemd unit(s)
 	Action       string // the action to perform with the unit
 	Enabled      bool   // enable the unit or not
-	ReloadDaemon bool   // Run daemon-reload before other actions
-	Scope        string // user or system
+	ReloadDaemon bool   // run daemon-reload before other actions
+	Scope        string // user, system or global
 	Force        bool   // add the `--force` arg to systemctl command
 }
 
@@ -55,7 +55,7 @@ func NewSystemdModule(config SystemdModuleConfig) *SystemdModule {
 
 	switch config.Scope {
 	case SystemdScopeUser:
-		sudo = false
+		sudo = false // `--user` scope does not need root priviledge
 		fallthrough
 	case SystemdScopeGlobal:
 		systemctl = fmt.Sprintf("%s --%s", config.Scope)

--- a/pkg/module/user.go
+++ b/pkg/module/user.go
@@ -34,7 +34,7 @@ const (
 	//usermodCmd = "/usr/sbin/usermod"
 )
 
-// UserModuleConfig is the configurations used to initialize a TiOpsModuleSystemd
+// UserModuleConfig is the configurations used to initialize a UserModule
 type UserModuleConfig struct {
 	Action string // add, del or modify user
 	Name   string // username
@@ -48,8 +48,7 @@ type UserModule struct {
 	cmd string // the built command
 }
 
-// NewUserModule builds and returns a TiOpsModuleSystemd object base on
-// given config.
+// NewUserModule builds and returns a UserModule object base on given config.
 func NewUserModule(config UserModuleConfig) *UserModule {
 	cmd := ""
 
@@ -57,12 +56,12 @@ func NewUserModule(config UserModuleConfig) *UserModule {
 	case UserActionAdd:
 		cmd = useraddCmd
 		// set user's home
-		if len(config.Home) > 0 {
+		if config.Home != "" {
 			cmd = fmt.Sprintf("/usr/bin/mkdir -p %s && %s -d %s",
 				config.Home, cmd, config.Home)
 		}
 		// set user's login shell
-		if len(config.Shell) > 0 {
+		if config.Shell != "" {
 			cmd = fmt.Sprintf("%s -s %s", config.Shell)
 		} else {
 			cmd = fmt.Sprintf("%s -s %s", defaultShell)
@@ -101,7 +100,7 @@ func (mod *UserModule) Execute(exec executor.TiOpsExecutor) ([]byte, []byte, err
 }
 
 func buildBashInsertLine(line string, file string) string {
-	if len(line) < 1 || len(file) < 1 {
+	if line == "" || file == "" {
 		return ""
 	}
 	return fmt.Sprintf("grep -qxF '%s' %s || echo '%s' >> %s",

--- a/pkg/module/user.go
+++ b/pkg/module/user.go
@@ -1,0 +1,109 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package module
+
+import (
+	"fmt"
+
+	"github.com/pingcap-incubator/tiops/pkg/executor"
+)
+
+const (
+	defaultShell = "/bin/bash"
+
+	UserActionAdd = "add"
+	UserActionDel = "del"
+	//UserActionModify = "modify"
+
+	// TODO: in RHEL/CentOS, the commands are in /usr/sbin, but in some
+	// other distros they may be in other location such as /usr/bin, we'll
+	// need to check and find the proper path of commands in the future.
+	useraddCmd = "/usr/sbin/useradd"
+	userdelCmd = "/usr/sbin/userdel"
+	//usermodCmd = "/usr/sbin/usermod"
+)
+
+// UserModuleConfig is the configurations used to initialize a TiOpsModuleSystemd
+type UserModuleConfig struct {
+	Action string // add, del or modify user
+	Name   string // username
+	Home   string // home directory of user
+	Shell  string // login shell of the user
+	Sudoer bool   // when true, the user will be added to sudoers list
+}
+
+// UserModule is the module used to control systemd units
+type UserModule struct {
+	cmd string // the built command
+}
+
+// NewUserModule builds and returns a TiOpsModuleSystemd object base on
+// given config.
+func NewUserModule(config UserModuleConfig) *UserModule {
+	cmd := ""
+
+	switch config.Action {
+	case UserActionAdd:
+		cmd = useraddCmd
+		// set user's home
+		if len(config.Home) > 0 {
+			cmd = fmt.Sprintf("/usr/bin/mkdir -p %s && %s -d %s",
+				config.Home, cmd, config.Home)
+		}
+		// set user's login shell
+		if len(config.Shell) > 0 {
+			cmd = fmt.Sprintf("%s -s %s", config.Shell)
+		} else {
+			cmd = fmt.Sprintf("%s -s %s", defaultShell)
+		}
+
+		cmd = fmt.Sprintf("%s %s", cmd, config.Name)
+
+		// prevent errors when username already in use
+		cmd = fmt.Sprintf("%s || [ $? -eq 9]", cmd)
+
+		// add user to sudoers list
+		if config.Sudoer {
+			sudoLine := fmt.Sprintf("%s ALL=(ALL) NOPASSWD:ALL",
+				config.Name)
+			cmd = fmt.Sprintf("%s && %s",
+				buildBashInsertLine(sudoLine, "/etc/suduers"))
+		}
+	case UserActionDel:
+		cmd = fmt.Sprintf("%s -r %s", userdelCmd, config.Name)
+		// prevent errors when user does not exist
+		cmd = fmt.Sprintf("%s || [ $? -eq 6 ]", cmd)
+
+		//	case UserActionModify:
+		//		cmd = usermodCmd
+	}
+
+	return &UserModule{
+		cmd: cmd,
+	}
+}
+
+// Execute passes the command to executor and returns its results, the executor
+// should be already initialized.
+func (mod *UserModule) Execute(exec executor.TiOpsExecutor) ([]byte, []byte, error) {
+	return exec.Execute(mod.cmd, true)
+}
+
+func buildBashInsertLine(line string, file string) string {
+	if len(line) < 1 || len(file) < 1 {
+		return ""
+	}
+	return fmt.Sprintf("grep -qxF '%s' %s || echo '%s' >> %s",
+		line, file, line, file)
+}


### PR DESCRIPTION
Implemented some basic modules against executor:
 - `systemd` to wrap `systemctl` command and control systemd units
 - `user` to wrap `useradd`/`userdel` commands and manages Linux users
 - `shell` to wrap shell and run commands remotely

All modules has a `NewX()` function to parse its config, and a `Execute()` function to run command with specific executor, the executor should be initialized before passing to `Execute()` function of modules.