### PR TITLE
Make deploy/start/stop/restart work

### DIFF
--- a/pkg/meta/topology.go
+++ b/pkg/meta/topology.go
@@ -183,7 +183,8 @@ func (s TiKVSpec) Role() string {
 
 // PDSpec represents the PD topology specification in topology.yaml
 type PDSpec struct {
-	Name       string `yaml:"name"`
+	// Use GetName() to get the name with a default value if it's empty.
+	ConfigName string `yaml:"name"`
 	Host       string `yaml:"host"`
 	ClientPort int    `yaml:"client_port" default:"2379"`
 	PeerPort   int    `yaml:"peer_port" default:"2380"`
@@ -192,6 +193,16 @@ type PDSpec struct {
 	DeployDir  string `yaml:"deploy_dir,omitempty"`
 	DataDir    string `yaml:"data_dir,omitempty"`
 	NumaNode   bool   `yaml:"numa_node,omitempty"`
+}
+
+// GetName return the name.
+// return "pd-{host}-{port} if it's not setted.
+func (s PDSpec) GetName() string {
+	if s.ConfigName != "" {
+		return s.ConfigName
+	}
+
+	return fmt.Sprintf("pd-%s-%d", s.Host, s.ClientPort)
 }
 
 // GetID returns the UUID of the instance

--- a/pkg/operation/action.go
+++ b/pkg/operation/action.go
@@ -208,16 +208,17 @@ func getServiceStatus(e executor.TiOpsExecutor, name string) (active string, err
 	}
 	systemd := module.NewSystemdModule(c)
 	stdout, _, err := systemd.Execute(e)
+
+	lines := strings.Split(string(stdout), "\n")
+	if len(lines) >= 3 {
+		return lines[2], nil
+	}
+
 	if err != nil {
 		return
 	}
 
-	lines := strings.Split(string(stdout), "\n")
-	if len(lines) < 3 {
-		return "", errors.Errorf("unexpected output: %s", string(stdout))
-	}
-
-	return lines[2], nil
+	return "", errors.Errorf("unexpected output: %s", string(stdout))
 }
 
 // PrintClusterStatus print cluster status into the io.Writer.

--- a/pkg/template/scripts/pd.go
+++ b/pkg/template/scripts/pd.go
@@ -15,7 +15,7 @@ package scripts
 
 import (
 	"bytes"
-	"fmt"
+	"errors"
 	"io/ioutil"
 	"os"
 	"path"
@@ -108,8 +108,14 @@ func (c *PDScript) ConfigWithTemplate(tpl string) ([]byte, error) {
 	}
 
 	if c.Name == "" {
-		c.Name = fmt.Sprintf("pd-%s-%d", c.IP, c.ClientPort)
+		return nil, errors.New("empty name")
 	}
+	for _, s := range c.Endpoints {
+		if s.Name == "" {
+			return nil, errors.New("empty name")
+		}
+	}
+
 	content := bytes.NewBufferString("")
 	if err := tmpl.Execute(content, c); err != nil {
 		return nil, err

--- a/pkg/template/systemd/system.go
+++ b/pkg/template/systemd/system.go
@@ -32,6 +32,10 @@ type Config struct {
 	IOReadBandwidthMax  uint
 	IOWriteBandwidthMax uint
 	DeployDir           string
+	DisableSendSigkill  bool
+	// Takes one of no, on-success, on-failure, on-abnormal, on-watchdog, on-abort, or always.
+	// The Template set as always if this is not setted.
+	Restart string
 }
 
 // NewConfig returns a Config with given arguments

--- a/templates/scripts/run_tidb.sh.tpl
+++ b/templates/scripts/run_tidb.sh.tpl
@@ -1,4 +1,3 @@
-  
 #!/bin/bash
 set -e
 

--- a/templates/systemd/system.service.tpl
+++ b/templates/systemd/system.service.tpl
@@ -19,10 +19,17 @@ LimitNOFILE=1000000
 #LimitCORE=infinity
 LimitSTACK=10485760
 User={{.User}}
-ExecStart=/bin/sh {{.DeployDir}}/scripts/run_{{.ServiceName}}.sh
-Restart=on-failure
+ExecStart={{.DeployDir}}/scripts/run_{{.ServiceName}}.sh
+{{- if .Restart}}
+Restart={{.Restart}}
+{{else}}
+Restart=always
+{{end}}
 RestartSec=15s
+{{- if .DisableSendSigkill}}
 SendSIGKILL=no
+{{- end}}
+
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
- Fix the Name of pd is empty if the run_pd.sh
- Make systemd service tpl as the one ansible use
  - not using DisableSendSigkill now, in ansible, pump&drainer will use
  this, but i think better remove this.

sometimes will fail to restart like this:
```
Stopping component tikv
Stopping instance 172.19.0.4
Error: connection timed out to 172.19.0.4:22
failed to stop: 172.19.0.4
github.com/pingcap-incubator/tiops/pkg/operation.StopComponent
	/Users/huangjiahao/go/src/github.com/pingcap-incubator/tiops/pkg/operation/action.go:176
github.com/pingcap-incubator/tiops/pkg/operation.Restart
	/Users/huangjiahao/go/src/github.com/pingcap-incubator/tiops/pkg/operation/action.go:81
``` 
maybe caused by the instance can't quit quickly, will improve it later.

normally case:
start:
![Screen Shot 2020-03-26 at 12 17 17 PM](https://user-images.githubusercontent.com/1681864/77610967-0c782c80-6f5f-11ea-831e-f1e94bcb5303.png)
stop:
![Screen Shot 2020-03-26 at 12 17 36 PM](https://user-images.githubusercontent.com/1681864/77610976-1437d100-6f5f-11ea-956e-185715590e45.png)
restart:
![Screen Shot 2020-03-26 at 12 35 08 PM](https://user-images.githubusercontent.com/1681864/77610998-1e59cf80-6f5f-11ea-93d3-dbf4baef8eff.png)
