### PR TITLE
*: various fixes when validating deploy process

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -157,7 +157,7 @@ func deploy(name, topoFile string, opt deployOptions) error {
 					filepath.Join(deployDir, "scripts"),
 					filepath.Join(deployDir, "logs")).
 				CopyComponent(inst.ComponentName(), version, inst.GetHost(), deployDir).
-				InitConfig(name, inst, deployDir).
+				InitConfig(name, inst, opt.deployUser, deployDir).
 				Build()
 			copyCompTasks = append(copyCompTasks, t)
 		}

--- a/cmd/display.go
+++ b/cmd/display.go
@@ -104,7 +104,10 @@ func displayClusterTopology(opt *displayOption) error {
 	pdList := topo.GetPDList()
 	for _, comp := range topo.ComponentsByStartOrder() {
 		for _, ins := range comp.Instances() {
-			if !filterRoles.Exist(ins.Role()) || !filterNodes.Exist(ins.ID()) {
+			if len(filterRoles) > 0 && !filterRoles.Exist(ins.Role()) {
+				continue
+			}
+			if len(filterNodes) > 0 && !filterNodes.Exist(ins.ID()) {
 				continue
 			}
 

--- a/cmd/display.go
+++ b/cmd/display.go
@@ -104,9 +104,11 @@ func displayClusterTopology(opt *displayOption) error {
 	pdList := topo.GetPDList()
 	for _, comp := range topo.ComponentsByStartOrder() {
 		for _, ins := range comp.Instances() {
+			// apply role filter
 			if len(filterRoles) > 0 && !filterRoles.Exist(ins.Role()) {
 				continue
 			}
+			// apply node filter
 			if len(filterNodes) > 0 && !filterNodes.Exist(ins.ID()) {
 				continue
 			}

--- a/cmd/scale_in.go
+++ b/cmd/scale_in.go
@@ -58,7 +58,7 @@ func scaleIn(cluster string, nodeIds []string) error {
 			if !strings.HasPrefix(deployDir, "/") {
 				deployDir = filepath.Join("/home/"+metadata.User+"/deploy", deployDir)
 			}
-			t := task.NewBuilder().InitConfig(cluster, instance, deployDir).Build()
+			t := task.NewBuilder().InitConfig(cluster, instance, metadata.User, deployDir).Build()
 			regenConfigTasks = append(regenConfigTasks, t)
 		}
 	}

--- a/pkg/executor/ssh.go
+++ b/pkg/executor/ssh.go
@@ -86,6 +86,9 @@ func (sshExec *SSHExecutor) Execute(cmd string, sudo bool, timeout ...time.Durat
 		cmd = fmt.Sprintf("sudo -H -u root %s", cmd)
 	}
 
+	// set a basic PATH in case it's empty on login
+	cmd = fmt.Sprintf("PATH=$PATH:/usr/bin:/usr/sbin %s", cmd)
+
 	// run command on remote host
 	// default timeout is 60s in easyssh-proxy
 	stdout, stderr, done, err := sshExec.Config.Run(cmd, timeout...)

--- a/pkg/executor/ssh.go
+++ b/pkg/executor/ssh.go
@@ -98,7 +98,7 @@ func (sshExec *SSHExecutor) Execute(cmd string, sudo bool, timeout ...time.Durat
 
 	if !done { // timeout case,
 		return []byte(stdout), []byte(stderr),
-			fmt.Errorf("timeout to run: %s on %s:%s",
+			fmt.Errorf("timed out running \"%s\" on %s:%s",
 				cmd,
 				sshExec.Config.Server,
 				sshExec.Config.Port)

--- a/pkg/meta/logic.go
+++ b/pkg/meta/logic.go
@@ -53,7 +53,7 @@ type Instance interface {
 	ID() string
 	Ready(executor.TiOpsExecutor) error
 	WaitForDown(executor.TiOpsExecutor) error
-	InitConfig(executor.TiOpsExecutor, string, string) error
+	InitConfig(executor.TiOpsExecutor, string, string, string) error
 	ComponentName() string
 	InstanceName() string
 	ServiceName() string
@@ -109,12 +109,12 @@ func (i *instance) WaitForDown(e executor.TiOpsExecutor) error {
 	return portStopped(e, i.port)
 }
 
-func (i *instance) InitConfig(e executor.TiOpsExecutor, cacheDir, deployDir string) error {
+func (i *instance) InitConfig(e executor.TiOpsExecutor, user, cacheDir, deployDir string) error {
 	comp := i.ComponentName()
 	port := i.GetPort()
 	sysCfg := filepath.Join(cacheDir, fmt.Sprintf("%s-%d.service", comp, port))
 
-	systemCfg := system.NewConfig(comp, "tidb", deployDir)
+	systemCfg := system.NewConfig(comp, user, deployDir)
 	// For not auto start if using binlogctl to offline.
 	// bad design
 	if comp == ComponentPump || comp == ComponentDrainer {
@@ -239,8 +239,8 @@ type TiDBInstance struct {
 }
 
 // InitConfig implement Instance interface
-func (i *TiDBInstance) InitConfig(e executor.TiOpsExecutor, cacheDir, deployDir string) error {
-	if err := i.instance.InitConfig(e, cacheDir, deployDir); err != nil {
+func (i *TiDBInstance) InitConfig(e executor.TiOpsExecutor, user, cacheDir, deployDir string) error {
+	if err := i.instance.InitConfig(e, user, cacheDir, deployDir); err != nil {
 		return err
 	}
 	ends := []*scripts.PDScript{}
@@ -306,8 +306,8 @@ type TiKVInstance struct {
 }
 
 // InitConfig implement Instance interface
-func (i *TiKVInstance) InitConfig(e executor.TiOpsExecutor, cacheDir, deployDir string) error {
-	if err := i.instance.InitConfig(e, cacheDir, deployDir); err != nil {
+func (i *TiKVInstance) InitConfig(e executor.TiOpsExecutor, user, cacheDir, deployDir string) error {
+	if err := i.instance.InitConfig(e, user, cacheDir, deployDir); err != nil {
 		return err
 	}
 
@@ -387,8 +387,8 @@ type PDInstance struct {
 }
 
 // InitConfig implement Instance interface
-func (i *PDInstance) InitConfig(e executor.TiOpsExecutor, cacheDir, deployDir string) error {
-	if err := i.instance.InitConfig(e, cacheDir, deployDir); err != nil {
+func (i *PDInstance) InitConfig(e executor.TiOpsExecutor, user, cacheDir, deployDir string) error {
+	if err := i.instance.InitConfig(e, user, cacheDir, deployDir); err != nil {
 		return err
 	}
 

--- a/pkg/module/wait_for.go
+++ b/pkg/module/wait_for.go
@@ -73,6 +73,7 @@ func (w *WaitFor) Execute(e executor.TiOpsExecutor) (err error) {
 		}
 		return err
 	}, retryOpt); err != nil {
+		// TODO: add a debug log about the real err returned by utils.Retry()
 		return errors.Errorf("timed out waiting for port %d to be %s", w.c.Port, w.c.State)
 	}
 	return nil

--- a/pkg/module/wait_for.go
+++ b/pkg/module/wait_for.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/pingcap-incubator/tiops/pkg/executor"
+	"github.com/pingcap-incubator/tiops/pkg/utils"
 	"github.com/pingcap/errors"
 )
 
@@ -47,29 +48,30 @@ func NewWaitFor(c WaitForConfig) *WaitFor {
 
 // Execute the module return nil if successfully wait for the event.
 func (w *WaitFor) Execute(e executor.TiOpsExecutor) (err error) {
-	// netstat -tunlp | grep ":4000 "
+	pattern := []byte(fmt.Sprintf(":%d ", w.c.Port))
 
-	start := time.Now()
-	patern := []byte(fmt.Sprintf(":%d ", w.c.Port))
-
-	for {
-		stdout, _, err := e.Execute("netstat -tunlp", false)
+	retryOpt := utils.RetryOption{
+		Attempts: 60,
+		Delay:    w.c.Sleep,
+		Timeout:  w.c.Timeout,
+	}
+	if err := utils.Retry(func() error {
+		stdout, _, err := e.Execute("ss -lnt", false)
 		if err == nil {
 			switch w.c.State {
 			case "started":
-				if bytes.Contains(stdout, patern) {
+				if bytes.Contains(stdout, pattern) {
 					return nil
 				}
 			case "stopped":
-				if !bytes.Contains(stdout, patern) {
+				if !bytes.Contains(stdout, pattern) {
 					return nil
 				}
 			}
 		}
-
-		if time.Since(start) >= w.c.Timeout {
-			return errors.Errorf("timeout to wait for port %s", w.c.State)
-		}
-		time.Sleep(w.c.Sleep)
+		return err
+	}, retryOpt); err != nil {
+		return errors.Errorf("timeout to wait for port %d to be %s", w.c.Port, w.c.State)
 	}
+	return nil
 }

--- a/pkg/module/wait_for.go
+++ b/pkg/module/wait_for.go
@@ -56,7 +56,8 @@ func (w *WaitFor) Execute(e executor.TiOpsExecutor) (err error) {
 		Timeout:  w.c.Timeout,
 	}
 	if err := utils.Retry(func() error {
-		stdout, _, err := e.Execute("ss -lnt", false)
+		// only listing TCP ports
+		stdout, _, err := e.Execute("ss -ltn", false)
 		if err == nil {
 			switch w.c.State {
 			case "started":
@@ -71,7 +72,7 @@ func (w *WaitFor) Execute(e executor.TiOpsExecutor) (err error) {
 		}
 		return err
 	}, retryOpt); err != nil {
-		return errors.Errorf("timeout to wait for port %d to be %s", w.c.Port, w.c.State)
+		return errors.Errorf("timed out waiting for port %d to be %s", w.c.Port, w.c.State)
 	}
 	return nil
 }

--- a/pkg/module/wait_for.go
+++ b/pkg/module/wait_for.go
@@ -69,6 +69,7 @@ func (w *WaitFor) Execute(e executor.TiOpsExecutor) (err error) {
 					return nil
 				}
 			}
+			return errors.New("still waiting for port state to be satisfied")
 		}
 		return err
 	}, retryOpt); err != nil {

--- a/pkg/task/builder.go
+++ b/pkg/task/builder.go
@@ -122,11 +122,12 @@ func (b *Builder) BackupComponent(component, fromVer string, dstHost, dstDir str
 }
 
 // InitConfig appends a CopyComponent task to the current task collection
-func (b *Builder) InitConfig(name string, inst meta.Instance, deployDir string) *Builder {
+func (b *Builder) InitConfig(name string, inst meta.Instance, deployUser, deployDir string) *Builder {
 	b.tasks = append(b.tasks, &InitConfig{
-		name:      name,
-		instance:  inst,
-		deployDir: deployDir,
+		name:       name,
+		instance:   inst,
+		deployUser: deployUser,
+		deployDir:  deployDir,
 	})
 	return b
 }

--- a/pkg/task/init_config.go
+++ b/pkg/task/init_config.go
@@ -21,9 +21,10 @@ import (
 
 // InitConfig is used to copy all configurations to the target directory of path
 type InitConfig struct {
-	name      string
-	instance  meta.Instance
-	deployDir string
+	name       string
+	instance   meta.Instance
+	deployUser string
+	deployDir  string
 }
 
 // Execute implements the Task interface
@@ -39,7 +40,7 @@ func (c *InitConfig) Execute(ctx *Context) error {
 		return err
 	}
 
-	return c.instance.InitConfig(exec, cacheConfigDir, c.deployDir)
+	return c.instance.InitConfig(exec, c.deployUser, cacheConfigDir, c.deployDir)
 }
 
 // Rollback implements the Task interface

--- a/pkg/template/scripts/tikv.go
+++ b/pkg/template/scripts/tikv.go
@@ -72,7 +72,7 @@ func (c *TiKVScript) AppendEndpoints(ends ...*PDScript) *TiKVScript {
 // Config read ${localdata.EnvNameComponentInstallDir}/templates/scripts/run_TiKV.sh.tpl as template
 // and generate the config by ConfigWithTemplate
 func (c *TiKVScript) Config() ([]byte, error) {
-	fp := path.Join(os.Getenv(localdata.EnvNameComponentInstallDir), "templates", "scripts", "run_TiKV.sh.tpl")
+	fp := path.Join(os.Getenv(localdata.EnvNameComponentInstallDir), "templates", "scripts", "run_tikv.sh.tpl")
 	tpl, err := ioutil.ReadFile(fp)
 	if err != nil {
 		return nil, err

--- a/templates/systemd/system.service.tpl
+++ b/templates/systemd/system.service.tpl
@@ -18,8 +18,10 @@ IOWriteBandwidthMax={{.IOWriteBandwidthMax}}
 LimitNOFILE=1000000
 #LimitCORE=infinity
 LimitSTACK=10485760
+
 User={{.User}}
 ExecStart={{.DeployDir}}/scripts/run_{{.ServiceName}}.sh
+
 {{- if .Restart}}
 Restart={{.Restart}}
 {{else}}
@@ -29,7 +31,6 @@ RestartSec=15s
 {{- if .DisableSendSigkill}}
 SendSIGKILL=no
 {{- end}}
-
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
 * Fix role and node filtering for `display`
 * Set correct username in systemd service files (It was hard coded to `tidb`)
 * Fix retrying function in utils
 * Use `ss` instead of `netstat` in the `wait_for` module to check for listening port, many modern distros are shipping `net-tools` (provides `netstat`) by default anymore
 * Set a basic `PATH` value for every SSH commands, in case the value is empty on login