### PR TITLE
executor: fix sudo command to allow multiple commands

### DIFF
--- a/pkg/executor/ssh.go
+++ b/pkg/executor/ssh.go
@@ -83,7 +83,7 @@ func (sshExec *SSHExecutor) Initialize(config SSHConfig) error {
 func (sshExec *SSHExecutor) Execute(cmd string, sudo bool, timeout ...time.Duration) ([]byte, []byte, error) {
 	// try to acquire root permission
 	if sudo {
-		cmd = fmt.Sprintf("sudo -H -u root %s", cmd)
+		cmd = fmt.Sprintf("sudo -H -u root bash -c \"%s\"", cmd)
 	}
 
 	// set a basic PATH in case it's empty on login

--- a/pkg/operation/destroy.go
+++ b/pkg/operation/destroy.go
@@ -51,7 +51,7 @@ func DestroyComponent(getter ExecutorGetter, w io.Writer, instances []meta.Insta
 		command = command + fmt.Sprintf("rm -rf %s;", ins.DeployDir()) + fmt.Sprintf("rm -rf /etc/systemd/system/%s;", ins.ServiceName())
 		c := module.ShellModuleConfig{
 			Command:  command,
-			Sudo:     false,
+			Sudo:     true, // the .service files are in a directory owned by root
 			Chdir:    "",
 			UseShell: false,
 		}


### PR DESCRIPTION
When passing a command sequence like `cmd1 ; cmd2` to the SSH executor and set `sudo` flag, only the first command got executed with sudo, this PR fix this.