### PR TITLE
deploy monitored/monitoring/grafana/altermanager components

### DIFF
--- a/pkg/meta/topology.go
+++ b/pkg/meta/topology.go
@@ -237,29 +237,31 @@ func (s AlertManagerSpec) Role() string {
 	return RoleMonitor
 }
 
-/*
 // TopologyGlobalOptions represents the global options for all groups in topology
 // pecification in topology.yaml
 type TopologyGlobalOptions struct {
-	SSHPort              int    `yaml:"ssh_port,omitempty" default:"22"`
-	DeployDir            string `yaml:"deploy_dir,omitempty"`
-	DataDir              string `yaml:"data_dir,omitempty"`
+	SSHPort int `yaml:"ssh_port,omitempty" default:"22"`
+}
+
+type MonitoredOptions struct {
+	DeployDir            string `yaml:"deploy_dir,omitempty" default:"monitored"`
+	DataDir              string `yaml:"data_dir,omitempty"  default:"monitored/data"`
 	NodeExporterPort     int    `yaml:"node_exporter_port,omitempty" default:"9100"`
 	BlackboxExporterPort int    `yaml:"blackbox_exporter_port,omitempty" default:"9115"`
 }
-*/
 
 // TopologySpecification represents the specification of topology.yaml
 type TopologySpecification struct {
-	//GlobalOptions TopologyGlobalOptions `yaml:"global,omitempty"`
-	TiDBServers  []TiDBSpec         `yaml:"tidb_servers"`
-	TiKVServers  []TiKVSpec         `yaml:"tikv_servers"`
-	PDServers    []PDSpec           `yaml:"pd_servers"`
-	PumpServers  []PumpSpec         `yaml:"pump_servers,omitempty"`
-	Drainers     []DrainerSpec      `yaml:"drainer_servers,omitempty"`
-	Monitors     []PrometheusSpec   `yaml:"monitoring_servers"`
-	Grafana      []GrafanaSpec      `yaml:"grafana_servers,omitempty"`
-	Alertmanager []AlertManagerSpec `yaml:"alertmanager_servers,omitempty"`
+	GlobalOptions    TopologyGlobalOptions `yaml:"global,omitempty"`
+	MonitoredOptions MonitoredOptions      `yaml:"monitored,omitempty"`
+	TiDBServers      []TiDBSpec            `yaml:"tidb_servers"`
+	TiKVServers      []TiKVSpec            `yaml:"tikv_servers"`
+	PDServers        []PDSpec              `yaml:"pd_servers"`
+	PumpServers      []PumpSpec            `yaml:"pump_servers,omitempty"`
+	Drainers         []DrainerSpec         `yaml:"drainer_servers,omitempty"`
+	Monitors         []PrometheusSpec      `yaml:"monitoring_servers"`
+	Grafana          []GrafanaSpec         `yaml:"grafana_servers,omitempty"`
+	Alertmanager     []AlertManagerSpec    `yaml:"alertmanager_servers,omitempty"`
 }
 
 // UnmarshalYAML sets default values when unmarshaling the topology file
@@ -300,6 +302,12 @@ func (topo *TopologySpecification) Merge(that *TopologySpecification) *TopologyS
 		Grafana:      append(topo.Grafana, that.Grafana...),
 		Alertmanager: append(topo.Alertmanager, that.Alertmanager...),
 	}
+}
+
+// Validate validates the topology specification and produce error if
+// the specification invalid
+func (topo *TopologySpecification) Validate() error {
+	return nil
 }
 
 // fillDefaults tries to fill custom fields to their default values

--- a/pkg/task/builder.go
+++ b/pkg/task/builder.go
@@ -144,6 +144,17 @@ func (b *Builder) ScaleConfig(name string, base *meta.TopologySpecification, ins
 	return b
 }
 
+// MonitoredConfig appends a CopyComponent task to the current task collection
+func (b *Builder) MonitoredConfig(name string, options meta.MonitoredOptions, deployUser, deployDir string) *Builder {
+	b.tasks = append(b.tasks, &MonitoredConfig{
+		name:       name,
+		options:    options,
+		deployUser: deployUser,
+		deployDir:  deployDir,
+	})
+	return b
+}
+
 // SSHKeyGen appends a SSHKeyGen task to the current task collection
 func (b *Builder) SSHKeyGen(keypath string) *Builder {
 	b.tasks = append(b.tasks, &SSHKeyGen{

--- a/pkg/task/monitored_config.go
+++ b/pkg/task/monitored_config.go
@@ -1,0 +1,36 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package task
+
+import (
+	"fmt"
+
+	"github.com/pingcap-incubator/tiops/pkg/meta"
+)
+
+type MonitoredConfig struct {
+	name       string
+	options    meta.MonitoredOptions
+	deployUser string
+	deployDir  string
+}
+
+func (m *MonitoredConfig) Execute(ctx *Context) error {
+	fmt.Println("TODO: ====> MonitoredConfig")
+	return nil
+}
+
+func (m *MonitoredConfig) Rollback(ctx *Context) error {
+	return ErrUnsupportRollback
+}


### PR DESCRIPTION
```
tidb_servers:
  - host: n1
  - host: n2
  - host: n3

pd_servers:
  - host: n2
  - host: n4
  - host: n5

tikv_servers:
  - host: n1
  - host: n2
  - host: n4
  - host: n5
  - host: n3

grafana_servers:
  - host: n1

monitoring_servers:
  - host: n2

alertmanager_servers:
  - host: n3
```