### PR TITLE
save cluster meta after scale out

### DIFF
--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -129,5 +129,11 @@ func upgrade(name string, opt upgradeOptions) error {
 		ClusterOperate(metadata.Topology, operator.UpgradeOperation, opt.options).
 		Build()
 
-	return t.Execute(task.NewContext())
+	err = t.Execute(task.NewContext())
+	if err != nil {
+		return err
+	}
+
+	metadata.Version = opt.version
+	return meta.SaveClusterMeta(name, metadata)
 }


### PR DESCRIPTION
* save cluster meta after scaling out
* use `deployUser` but not `user` when scaling out
* save metadata after upgrading

Signed-off-by: Yang Keao <keao.yang@yahoo.com>