### PR TITLE
support global options for topology specification

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -36,9 +36,7 @@ type componentInfo struct {
 }
 
 type deployOptions struct {
-	version    string // version of the cluster
 	user       string // username to login to the SSH server
-	deployUser string // username of deploy tidb
 	password   string // password of the user
 	keyFile    string // path to the private key file
 	passphrase string // passphrase of the private key file
@@ -47,28 +45,24 @@ type deployOptions struct {
 func newDeploy() *cobra.Command {
 	opt := deployOptions{}
 	cmd := &cobra.Command{
-		Use:          "deploy <cluster-name> <topology.yaml>",
+		Use:          "deploy <cluster-name> <version> <topology.yaml>",
 		Short:        "Deploy a cluster for production",
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if len(args) != 2 {
+			if len(args) != 3 {
 				return cmd.Help()
 			}
 			if len(opt.keyFile) == 0 && len(opt.password) == 0 {
 				return errors.New("password and key need to specify at least one")
 			}
-			return deploy(args[0], args[1], opt)
+			return deploy(args[0], args[1], args[2], opt)
 		},
 	}
 
 	cmd.Flags().StringVar(&opt.user, "user", "root", "Specify the system user name")
-	cmd.Flags().StringVarP(&opt.deployUser, "deploy-user", "d", "tidb", "Specify the user name of deploy cluster")
 	cmd.Flags().StringVar(&opt.password, "password", "", "Specify the password of system user")
 	cmd.Flags().StringVar(&opt.keyFile, "key", "", "Specify the key path of system user")
 	cmd.Flags().StringVar(&opt.passphrase, "passphrase", "", "Specify the passphrase of the key")
-	cmd.Flags().StringVar(&opt.version, "version", "", "Specify the deploy version of cluster")
-
-	_ = cmd.MarkFlagRequired("version")
 
 	return cmd
 }
@@ -93,7 +87,7 @@ func getComponentVersion(comp, version string) repository.Version {
 	}
 }
 
-func deploy(name, topoFile string, opt deployOptions) error {
+func deploy(name, version, topoFile string, opt deployOptions) error {
 	if utils.IsExist(meta.ClusterPath(name)) {
 		return errors.Errorf("cluster name '%s' exists, please choose another cluster name", name)
 	}
@@ -124,10 +118,10 @@ func deploy(name, topoFile string, opt deployOptions) error {
 		uniqueHosts = set.NewStringSet()
 	)
 
-	// topo.NormalizeDeployDir("/home/" + opt.deployUser + "/deploy")
+	// topo.NormalizeDeployDir("/home/" + topo.GlobalOptions.User + "/deploy")
 	for _, comp := range topo.ComponentsByStartOrder() {
 		for idx, inst := range comp.Instances() {
-			version := getComponentVersion(inst.ComponentName(), opt.version)
+			version := getComponentVersion(inst.ComponentName(), version)
 			if version == "" {
 				return errors.Errorf("unsupported component: %v", inst.ComponentName())
 			}
@@ -145,26 +139,25 @@ func deploy(name, topoFile string, opt deployOptions) error {
 				uniqueHosts.Insert(inst.GetHost())
 				t := task.NewBuilder().
 					RootSSH(inst.GetHost(), inst.GetSSHPort(), opt.user, opt.password, opt.keyFile, opt.passphrase).
-					EnvInit(inst.GetHost(), opt.deployUser).
-					UserSSH(inst.GetHost(), opt.deployUser).
+					EnvInit(inst.GetHost(), topo.GlobalOptions.User).
+					UserSSH(inst.GetHost(), topo.GlobalOptions.User).
 					Build()
 				envInitTasks = append(envInitTasks, t)
 			}
 
 			deployDir := inst.DeployDir()
 			if !strings.HasPrefix(deployDir, "/") {
-				deployDir = filepath.Join("/home/"+opt.deployUser+"/deploy", deployDir)
+				deployDir = filepath.Join("/home/", topo.GlobalOptions.User, deployDir)
 			}
 			// Deploy component
 			t := task.NewBuilder().
 				Mkdir(inst.GetHost(),
 					filepath.Join(deployDir, "bin"),
-					filepath.Join(deployDir, "data"),
-					filepath.Join(deployDir, "config"),
+					filepath.Join(deployDir, "conf"),
 					filepath.Join(deployDir, "scripts"),
 					filepath.Join(deployDir, "logs")).
 				CopyComponent(inst.ComponentName(), version, inst.GetHost(), deployDir).
-				InitConfig(name, inst, opt.deployUser, deployDir).
+				InitConfig(name, inst, topo.GlobalOptions.User, deployDir).
 				Build()
 			copyCompTasks = append(copyCompTasks, t)
 		}
@@ -172,7 +165,7 @@ func deploy(name, topoFile string, opt deployOptions) error {
 
 	var monitoredCompTasks []task.Task
 	for _, comp := range []string{meta.ComponentNodeExporter, meta.ComponentBlackboxExporter} {
-		version := getComponentVersion(comp, opt.version)
+		version := getComponentVersion(comp, version)
 		if version == "" {
 			return errors.Errorf("unsupported component: %v", comp)
 		}
@@ -185,19 +178,18 @@ func deploy(name, topoFile string, opt deployOptions) error {
 		for host := range uniqueHosts {
 			deployDir := topo.MonitoredOptions.DeployDir
 			if !strings.HasPrefix(deployDir, "/") {
-				deployDir = filepath.Join("/home/"+opt.deployUser+"/deploy", deployDir)
+				deployDir = filepath.Join("/home/", topo.GlobalOptions.User, deployDir)
 			}
 
 			// Deploy component
 			t := task.NewBuilder().
 				Mkdir(host,
 					filepath.Join(deployDir, "bin"),
-					filepath.Join(deployDir, "data"),
-					filepath.Join(deployDir, "config"),
+					filepath.Join(deployDir, "conf"),
 					filepath.Join(deployDir, "scripts"),
 					filepath.Join(deployDir, "logs")).
 				CopyComponent(comp, version, host, deployDir).
-				MonitoredConfig(name, topo.MonitoredOptions, opt.deployUser, deployDir).
+				MonitoredConfig(name, topo.MonitoredOptions, topo.GlobalOptions.User, deployDir).
 				Build()
 			monitoredCompTasks = append(monitoredCompTasks, t)
 		}
@@ -212,13 +204,12 @@ func deploy(name, topoFile string, opt deployOptions) error {
 		Build()
 
 	if err := t.Execute(task.NewContext()); err != nil {
-		fmt.Println(err)
 		return errors.Trace(err)
 	}
 
 	return meta.SaveClusterMeta(name, &meta.ClusterMeta{
-		User:     opt.deployUser,
-		Version:  opt.version,
+		User:     topo.GlobalOptions.User,
+		Version:  version,
 		Topology: &topo,
 	})
 }

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -14,7 +14,6 @@
 package cmd
 
 import (
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"

--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -20,9 +20,9 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var options operator.Options
-
 func newDestroyCmd() *cobra.Command {
+	var options operator.Options
+
 	cmd := &cobra.Command{
 		Use:   "destroy <cluster-name>",
 		Short: "Destroy a specified cluster",

--- a/cmd/display.go
+++ b/cmd/display.go
@@ -52,8 +52,8 @@ func newDisplayCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringSliceVar(&opt.filterRole, "role", nil, "only display nodes of specific roles")
-	cmd.Flags().StringSliceVar(&opt.filterNode, "node", nil, "only display nodes of specific IDs")
+	cmd.Flags().StringSliceVarP(&opt.filterRole, "role", "R", nil, "Only display specified roles")
+	cmd.Flags().StringSliceVarP(&opt.filterNode, "node", "N", nil, "Only display specified nodes")
 
 	return cmd
 }

--- a/cmd/restart.go
+++ b/cmd/restart.go
@@ -52,7 +52,7 @@ func newRestartCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&options.Role, "role", "", "role name")
-	cmd.Flags().StringVar(&options.Node, "node-id", "", "node id")
+	cmd.Flags().StringVarP(&options.Role, "role", "R", "", "Only restart specified roles")
+	cmd.Flags().StringVarP(&options.Node, "node", "N", "", "Only restart specified nodes")
 	return cmd
 }

--- a/cmd/scale_in.go
+++ b/cmd/scale_in.go
@@ -42,7 +42,7 @@ func newScaleInCmd() *cobra.Command {
 			return scaleIn(args[0], nodes)
 		},
 	}
-	cmd.Flags().StringSliceVar(&nodes, "node-id", nil, "Specify the node ids")
+	cmd.Flags().StringSliceVarP(&nodes, "node", "N", nil, "Specify the nodes")
 	return cmd
 }
 
@@ -62,7 +62,7 @@ func scaleIn(cluster string, nodeIds []string) error {
 			}
 			deployDir := instance.DeployDir()
 			if !strings.HasPrefix(deployDir, "/") {
-				deployDir = filepath.Join("/home/"+metadata.User+"/deploy", deployDir)
+				deployDir = filepath.Join("/home/", metadata.User, deployDir)
 			}
 			t := task.NewBuilder().InitConfig(cluster, instance, metadata.User, deployDir).Build()
 			regenConfigTasks = append(regenConfigTasks, t)

--- a/cmd/scale_out.go
+++ b/cmd/scale_out.go
@@ -27,7 +27,6 @@ import (
 )
 
 type scaleOutOptions struct {
-	version    string // version of the cluster
 	user       string // username to login to the SSH server
 	password   string // password of the user
 	keyFile    string // path to the private key file
@@ -55,7 +54,6 @@ func newScaleOutCmd() *cobra.Command {
 	cmd.Flags().StringVar(&opt.password, "password", "", "Specify the password of system user")
 	cmd.Flags().StringVar(&opt.keyFile, "key", "", "Specify the key path of system user")
 	cmd.Flags().StringVar(&opt.passphrase, "passphrase", "", "Specify the passphrase of the key")
-	cmd.Flags().StringVar(&opt.version, "version", "", "Specify the deploy version of new nodes")
 
 	_ = cmd.MarkFlagRequired("version")
 
@@ -101,7 +99,7 @@ func bootstrapNewPart(name string, opt scaleOutOptions, newPart *meta.TopologySp
 	)
 	for _, comp := range newPart.ComponentsByStartOrder() {
 		for idx, inst := range comp.Instances() {
-			version := getComponentVersion(inst.ComponentName(), opt.version)
+			version := getComponentVersion(inst.ComponentName(), metadata.Version)
 			if version == "" {
 				return nil, errors.Errorf("unsupported component: %v", inst.ComponentName())
 			}
@@ -126,15 +124,14 @@ func bootstrapNewPart(name string, opt scaleOutOptions, newPart *meta.TopologySp
 
 			deployDir := inst.DeployDir()
 			if !strings.HasPrefix(deployDir, "/") {
-				deployDir = filepath.Join("/home/"+metadata.User+"/deploy", deployDir)
+				deployDir = filepath.Join("/home/", metadata.User, deployDir)
 			}
 			// Deploy component
 			t := task.NewBuilder().
 				UserSSH(inst.GetHost(), metadata.User).
 				Mkdir(inst.GetHost(),
 					filepath.Join(deployDir, "bin"),
-					filepath.Join(deployDir, "data"),
-					filepath.Join(deployDir, "config"),
+					filepath.Join(deployDir, "conf"),
 					filepath.Join(deployDir, "scripts"),
 					filepath.Join(deployDir, "logs")).
 				CopyComponent(inst.ComponentName(), version, inst.GetHost(), deployDir).
@@ -166,7 +163,7 @@ func refreshConfig(name string, opt scaleOutOptions, newPart *meta.Specification
 		for _, inst := range comp.Instances() {
 			deployDir := inst.DeployDir()
 			if !strings.HasPrefix(deployDir, "/") {
-				deployDir = filepath.Join("/home/"+metadata.User+"/deploy", deployDir)
+				deployDir = filepath.Join("/home/", metadata.User, deployDir)
 			}
 			t := task.NewBuilder().
 				UserSSH(inst.GetHost(), metadata.User).

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -53,7 +53,7 @@ func newStartCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&options.Role, "role", "", "role name")
-	cmd.Flags().StringVar(&options.Node, "node-id", "", "node id")
+	cmd.Flags().StringVarP(&options.Role, "role", "R", "", "Only start specified roles")
+	cmd.Flags().StringVarP(&options.Node, "node", "N", "", "Only start specified nodes")
 	return cmd
 }

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -52,7 +52,7 @@ func newStopCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&options.Role, "role", "", "role name")
-	cmd.Flags().StringVar(&options.Node, "node-id", "", "node id")
+	cmd.Flags().StringVarP(&options.Role, "role", "R", "", "Only stop specified roles")
+	cmd.Flags().StringVarP(&options.Node, "node", "N", "", "Only stop specified nodes")
 	return cmd
 }

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/google/uuid v1.1.1
 	github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a // indirect
 	github.com/juju/errors v0.0.0-20190930114154-d42613fe1ab9
-	github.com/kr/pretty v0.1.0 // indirect
 	github.com/lunixbochs/vtclean v1.0.0 // indirect
 	github.com/mattn/go-colorable v0.1.6 // indirect
 	github.com/pingcap-incubator/tiup v0.0.2-0.20200325070431-4ee17df76496

--- a/pkg/meta/logic.go
+++ b/pkg/meta/logic.go
@@ -330,8 +330,7 @@ func (i *TiKVInstance) InitConfig(e executor.TiOpsExecutor, user, cacheDir, depl
 	for _, spec := range i.instance.topo.PDServers {
 		ends = append(ends, scripts.NewPDScript(spec.Name, spec.Host, spec.DeployDir, spec.DataDir))
 	}
-	dataDir := i.instance.InstanceSpec.(*TiKVSpec).DataDir
-	cfg := scripts.NewTiKVScript(i.GetHost(), deployDir, dataDir).AppendEndpoints(ends...)
+	cfg := scripts.NewTiKVScript(i.GetHost(), deployDir, i.instance.DataDir()).AppendEndpoints(ends...)
 	fp := filepath.Join(cacheDir, fmt.Sprintf("run_tikv_%s_%d.sh", i.GetHost(), i.GetPort()))
 	if err := cfg.ConfigToFile(fp); err != nil {
 		return err
@@ -425,8 +424,7 @@ func (i *PDInstance) InitConfig(e executor.TiOpsExecutor, user, cacheDir, deploy
 		}
 		ends = append(ends, scripts.NewPDScript(spec.Name, spec.Host, spec.DeployDir, spec.DataDir))
 	}
-	dataDir := i.instance.InstanceSpec.(*PDSpec).DataDir
-	cfg := scripts.NewPDScript(name, i.GetHost(), deployDir, dataDir).AppendEndpoints(ends...)
+	cfg := scripts.NewPDScript(name, i.GetHost(), deployDir, i.instance.DataDir()).AppendEndpoints(ends...)
 	fp := filepath.Join(cacheDir, fmt.Sprintf("run_pd_%s.sh", i.GetHost()))
 	if err := cfg.ConfigToFile(fp); err != nil {
 		return err
@@ -455,8 +453,7 @@ func (i *PDInstance) ScaleConfig(e executor.TiOpsExecutor, b *Specification, use
 		ends = append(ends, scripts.NewPDScript(spec.Name, spec.Host, spec.DeployDir, spec.DataDir))
 	}
 
-	dataDir := i.instance.InstanceSpec.(*PDSpec).DataDir
-	cfg := scripts.NewPDScaleScript(name, i.GetHost(), deployDir, dataDir).AppendEndpoints(ends...)
+	cfg := scripts.NewPDScaleScript(name, i.GetHost(), deployDir, i.instance.DataDir()).AppendEndpoints(ends...)
 	fp := filepath.Join(cacheDir, fmt.Sprintf("run_pd_%s_%d.sh", i.GetHost(), i.GetPort()))
 	fmt.Println("script path:", fp)
 	if err := cfg.ConfigToFile(fp); err != nil {

--- a/pkg/meta/logic.go
+++ b/pkg/meta/logic.go
@@ -330,7 +330,8 @@ func (i *TiKVInstance) InitConfig(e executor.TiOpsExecutor, user, cacheDir, depl
 	for _, spec := range i.instance.topo.PDServers {
 		ends = append(ends, scripts.NewPDScript(spec.Name, spec.Host, spec.DeployDir, spec.DataDir))
 	}
-	cfg := scripts.NewTiKVScript(i.GetHost(), deployDir, filepath.Join(deployDir, "data")).AppendEndpoints(ends...)
+	dataDir := i.instance.InstanceSpec.(*TiKVSpec).DataDir
+	cfg := scripts.NewTiKVScript(i.GetHost(), deployDir, dataDir).AppendEndpoints(ends...)
 	fp := filepath.Join(cacheDir, fmt.Sprintf("run_tikv_%s_%d.sh", i.GetHost(), i.GetPort()))
 	if err := cfg.ConfigToFile(fp); err != nil {
 		return err
@@ -349,7 +350,7 @@ func (i *TiKVInstance) InitConfig(e executor.TiOpsExecutor, user, cacheDir, depl
 	if err := config.NewTiKVConfig().ConfigToFile(fp); err != nil {
 		return err
 	}
-	dst = filepath.Join(deployDir, "config", "tikv.toml")
+	dst = filepath.Join(deployDir, "conf", "tikv.toml")
 	if err := e.Transfer(fp, dst); err != nil {
 		return err
 	}
@@ -424,8 +425,8 @@ func (i *PDInstance) InitConfig(e executor.TiOpsExecutor, user, cacheDir, deploy
 		}
 		ends = append(ends, scripts.NewPDScript(spec.Name, spec.Host, spec.DeployDir, spec.DataDir))
 	}
-
-	cfg := scripts.NewPDScript(name, i.GetHost(), deployDir, filepath.Join(deployDir, "data")).AppendEndpoints(ends...)
+	dataDir := i.instance.InstanceSpec.(*PDSpec).DataDir
+	cfg := scripts.NewPDScript(name, i.GetHost(), deployDir, dataDir).AppendEndpoints(ends...)
 	fp := filepath.Join(cacheDir, fmt.Sprintf("run_pd_%s.sh", i.GetHost()))
 	if err := cfg.ConfigToFile(fp); err != nil {
 		return err
@@ -454,7 +455,8 @@ func (i *PDInstance) ScaleConfig(e executor.TiOpsExecutor, b *Specification, use
 		ends = append(ends, scripts.NewPDScript(spec.Name, spec.Host, spec.DeployDir, spec.DataDir))
 	}
 
-	cfg := scripts.NewPDScaleScript(name, i.GetHost(), deployDir, filepath.Join(deployDir, "data")).AppendEndpoints(ends...)
+	dataDir := i.instance.InstanceSpec.(*PDSpec).DataDir
+	cfg := scripts.NewPDScaleScript(name, i.GetHost(), deployDir, dataDir).AppendEndpoints(ends...)
 	fp := filepath.Join(cacheDir, fmt.Sprintf("run_pd_%s_%d.sh", i.GetHost(), i.GetPort()))
 	fmt.Println("script path:", fp)
 	if err := cfg.ConfigToFile(fp); err != nil {

--- a/pkg/meta/topology_test.go
+++ b/pkg/meta/topology_test.go
@@ -1,0 +1,55 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package meta
+
+import (
+	. "github.com/pingcap/check"
+	"gopkg.in/yaml.v2"
+	"testing"
+)
+
+type metaSuite struct {
+}
+
+var _ = Suite(&metaSuite{})
+
+func TestMeta(t *testing.T) {
+	TestingT(t)
+}
+
+func (s *metaSuite) TestGlobalOptions(c *C) {
+	topo := TopologySpecification{}
+	err := yaml.Unmarshal([]byte(`
+global:
+  user: "test1"
+  ssh_port: 220
+  deploy_dir: "test-deploy"
+  data_dir: "test-data" 
+tidb_servers:
+  - host: 172.16.5.138
+    deploy_dir: "tidb-deploy"
+pd_servers:
+  - host: 172.16.5.53
+    data_dir: "pd-data"
+`), &topo)
+	c.Assert(err, IsNil)
+	c.Assert(topo.GlobalOptions.User, Equals, "test1")
+	c.Assert(topo.GlobalOptions.SSHPort, Equals, 220)
+	c.Assert(topo.TiDBServers[0].SSHPort, Equals, 220)
+	c.Assert(topo.TiDBServers[0].DeployDir, Equals, "tidb-deploy")
+
+	c.Assert(topo.PDServers[0].SSHPort, Equals, 220)
+	c.Assert(topo.PDServers[0].DeployDir, Equals, "test-deploy/pd-2379")
+	c.Assert(topo.PDServers[0].DataDir, Equals, "pd-data")
+}

--- a/pkg/task/builder.go
+++ b/pkg/task/builder.go
@@ -225,5 +225,8 @@ func (b *Builder) Parallel(tasks ...Task) *Builder {
 
 // Build returns a task that contains all tasks appended by previous operation
 func (b *Builder) Build() Task {
+	if len(b.tasks) == 1 {
+		return b.tasks[0]
+	}
 	return Serial(b.tasks)
 }

--- a/templates/scripts/run_tikv.sh.tpl
+++ b/templates/scripts/run_tikv.sh.tpl
@@ -30,5 +30,5 @@ exec bin/tikv-server \
     --status-addr "{{.IP}}:{{.StatusPort}}" \
     --pd "{{template "PDList" .Endpoints}}" \
     --data-dir "{{.DataDir}}" \
-    --config config/tikv.toml \
+    --config conf/tikv.toml \
     --log-file "logs/tikv.log" 2>> "logs/tikv_stderr.log"

--- a/tests/topology.yaml
+++ b/tests/topology.yaml
@@ -5,6 +5,7 @@ tidb_servers:
 
 pd_servers:
   - host: 172.16.4.190
+    data_dir: "/data"
   - host: 172.16.5.158
   - host: 172.16.5.53
 


### PR DESCRIPTION
Signed-off-by: Lonng <heng@lonng.org>

This PR adds support global options for topology specification.

topo.yml
```
global:
  user: test3

monitored:
  node_exporter_port: 9100
  blackbox_exporter_port: 9110

tidb_servers:
  - host: 172.19.0.101

pd_servers:
  - host: 172.19.0.102
  - host: 172.19.0.104
  - host: 172.19.0.105

tikv_servers:
  - host: 172.19.0.103

#grafana_servers:
#  - host: 172.19.0.101
#
#monitoring_servers:
#  - host: 172.19.0.102
#
#alertmanager_servers:
#  - host: 172.19.0.103
```

manual test
```
bin/tiops deploy test3 v3.0.9 bin/docker-scale.yaml --key ~/.ssh/id_rsa
bin/tiops start test3
```