### PR TITLE
Make pump&drainer can deploy&started

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -160,9 +160,9 @@ func deploy(name, topoFile string, opt deployOptions) error {
 				Mkdir(inst.GetHost(),
 					filepath.Join(deployDir, "bin"),
 					filepath.Join(deployDir, "data"),
-					filepath.Join(deployDir, "config"),
+					filepath.Join(deployDir, "conf"),
 					filepath.Join(deployDir, "scripts"),
-					filepath.Join(deployDir, "logs")).
+					filepath.Join(deployDir, "log")).
 				CopyComponent(inst.ComponentName(), version, inst.GetHost(), deployDir).
 				InitConfig(name, inst, opt.deployUser, deployDir).
 				Build()
@@ -193,9 +193,9 @@ func deploy(name, topoFile string, opt deployOptions) error {
 				Mkdir(host,
 					filepath.Join(deployDir, "bin"),
 					filepath.Join(deployDir, "data"),
-					filepath.Join(deployDir, "config"),
+					filepath.Join(deployDir, "conf"),
 					filepath.Join(deployDir, "scripts"),
-					filepath.Join(deployDir, "logs")).
+					filepath.Join(deployDir, "log")).
 				CopyComponent(comp, version, host, deployDir).
 				MonitoredConfig(name, topo.MonitoredOptions, opt.deployUser, deployDir).
 				Build()

--- a/cmd/scale_out.go
+++ b/cmd/scale_out.go
@@ -142,9 +142,9 @@ func bootstrapNewPart(name string, opt scaleOutOptions, newPart *meta.TopologySp
 				Mkdir(inst.GetHost(),
 					filepath.Join(deployDir, "bin"),
 					filepath.Join(deployDir, "data"),
-					filepath.Join(deployDir, "config"),
+					filepath.Join(deployDir, "conf"),
 					filepath.Join(deployDir, "scripts"),
-					filepath.Join(deployDir, "logs")).
+					filepath.Join(deployDir, "log")).
 				CopyComponent(inst.ComponentName(), version, inst.GetHost(), deployDir).
 				ScaleConfig(name, oldPart, inst, metadata.User, deployDir).
 				Build()

--- a/docker/control/Dockerfile
+++ b/docker/control/Dockerfile
@@ -5,7 +5,7 @@ FROM golang:1.14
 RUN sed -i 's/archive.ubuntu.com/mirrors.aliyun.com/g' /etc/apt/sources.list
 RUN sed -i 's/security.ubuntu.com/mirrors.aliyun.com/g' /etc/apt/sources.list
 RUN sed -i 's/deb.debian.org/mirrors.aliyun.com/g' /etc/apt/sources.list
-RUN sed -i 's/security.debian.org/mirrors.aliyun.com/g' /etc/apt/sources.list
+# RUN sed -i 's/security.debian.org/mirrors.aliyun.com/g' /etc/apt/sources.list
 
 
 # tiops dependencies

--- a/docker/control/bashrc
+++ b/docker/control/bashrc
@@ -4,6 +4,17 @@ ssh-add /root/.ssh/id_rsa &> /dev/null
 export PATH=$PATH:/usr/local/go/bin
 export PATH=$PATH:/tiops/bin
 
+if [ -d "/mirrors" ]; then
+	export TIUP_MIRRORS=/mirrors
+fi
+
+# You may uncomment the following lines if you want `ls' to be colorized:
+export LS_OPTIONS='--color=auto'
+eval "`dircolors`"
+alias ls='ls $LS_OPTIONS'
+alias ll='ls $LS_OPTIONS -l'
+alias l='ls $LS_OPTIONS -lA'
+
 cat <<EOF
 Welcome to tiops on Docker
 ===========================

--- a/docker/control/init.sh
+++ b/docker/control/init.sh
@@ -14,6 +14,7 @@ if [ ! -f ~/.ssh/known_hosts ]; then
     done
 fi
 
+
 # TODO: assert that SSH_PRIVATE_KEY==~/.ssh/id_rsa
 
 cat <<EOF 

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -3,3 +3,4 @@ services:
   control:
     volumes:
       - ${TIOPS_ROOT}:/tiops # Mounts $TIOPS_ROOT on host to /tiops control container
+      - ${TIUP_MIRRORS:-/dev/null}:/mirrors

--- a/docker/node/Dockerfile
+++ b/docker/node/Dockerfile
@@ -14,6 +14,7 @@ sed -i "s/PermitRootLogin without-password/PermitRootLogin yes/g" /etc/ssh/sshd_
 
 ENV AUTHORIZED_KEYS **None**
 
+ADD ./bashrc /root/.bashrc
 ADD run.sh /run.sh
 RUN dos2unix /run.sh \
     && chmod +x /*.sh

--- a/docker/node/bashrc
+++ b/docker/node/bashrc
@@ -1,0 +1,8 @@
+
+
+# You may uncomment the following lines if you want `ls' to be colorized:
+export LS_OPTIONS='--color=auto'
+eval "`dircolors`"
+alias ls='ls $LS_OPTIONS'
+alias ll='ls $LS_OPTIONS -l'
+alias l='ls $LS_OPTIONS -lA'

--- a/pkg/meta/drainer.go
+++ b/pkg/meta/drainer.go
@@ -1,0 +1,97 @@
+package meta
+
+import (
+	"fmt"
+	"path/filepath"
+	"strconv"
+
+	"github.com/pingcap-incubator/tiops/pkg/executor"
+	"github.com/pingcap-incubator/tiops/pkg/template/config"
+	"github.com/pingcap-incubator/tiops/pkg/template/scripts"
+)
+
+// DrainerComponent represents Drainer component.
+type DrainerComponent struct{ *Specification }
+
+// Name implements Component interface.
+func (c *DrainerComponent) Name() string {
+	return ComponentDrainer
+}
+
+// Instances implements Component interface.
+func (c *DrainerComponent) Instances() []Instance {
+	ins := make([]Instance, 0, len(c.Drainers))
+	for _, s := range c.Drainers {
+		ins = append(ins, &DrainerInstance{instance{
+			InstanceSpec: s,
+			name:         c.Name(),
+			host:         s.Host,
+			port:         s.Port,
+			sshp:         s.SSHPort,
+			topo:         c.Specification,
+
+			usedPorts: []int{
+				s.Port,
+			},
+			usedDirs: []string{
+				s.DeployDir,
+				s.DataDir,
+			},
+			statusFn: func(_ ...string) string {
+				return "N/A"
+			},
+		}})
+	}
+	return ins
+}
+
+// DrainerInstance represent the Drainer instance.
+type DrainerInstance struct {
+	instance
+}
+
+// InitConfig implements Instance interface.
+func (i *DrainerInstance) InitConfig(e executor.TiOpsExecutor, user, cacheDir, deployDir string) error {
+	if err := i.instance.InitConfig(e, user, cacheDir, deployDir); err != nil {
+		return err
+	}
+
+	// transfer run script
+	ends := []*scripts.PDScript{}
+	for _, spec := range i.instance.topo.PDServers {
+		ends = append(ends, scripts.NewPDScript(spec.Name, spec.Host, spec.DeployDir, spec.DataDir))
+	}
+
+	cfg := scripts.NewDrainerScript(
+		i.GetHost()+":"+strconv.Itoa(i.GetPort()),
+		i.GetHost(),
+		deployDir,
+		filepath.Join(deployDir, "data"),
+	).AppendEndpoints(ends...)
+
+	fp := filepath.Join(cacheDir, fmt.Sprintf("run_drainer_%s_%d.sh", i.GetHost(), i.GetPort()))
+
+	if err := cfg.ConfigToFile(fp); err != nil {
+		return err
+	}
+	dst := filepath.Join(deployDir, "scripts", "run_drainer.sh")
+	if err := e.Transfer(fp, dst); err != nil {
+		return err
+	}
+
+	if _, _, err := e.Execute("chmod +x "+dst, false); err != nil {
+		return err
+	}
+
+	// transfer config
+	fp = filepath.Join(cacheDir, fmt.Sprintf("drainer_%s.toml", i.GetHost()))
+	if err := config.NewDrainerConfig().ConfigToFile(fp); err != nil {
+		return err
+	}
+	dst = filepath.Join(deployDir, "conf", "drainer.toml")
+	if err := e.Transfer(fp, dst); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/meta/logic.go
+++ b/pkg/meta/logic.go
@@ -349,7 +349,7 @@ func (i *TiKVInstance) InitConfig(e executor.TiOpsExecutor, user, cacheDir, depl
 	if err := config.NewTiKVConfig().ConfigToFile(fp); err != nil {
 		return err
 	}
-	dst = filepath.Join(deployDir, "config", "tikv.toml")
+	dst = filepath.Join(deployDir, "conf", "tikv.toml")
 	if err := e.Transfer(fp, dst); err != nil {
 		return err
 	}
@@ -468,76 +468,6 @@ func (i *PDInstance) ScaleConfig(e executor.TiOpsExecutor, b *Specification, use
 		return err
 	}
 	return nil
-}
-
-// PumpComponent represents Pump component.
-type PumpComponent struct{ *Specification }
-
-// Name implements Component interface.
-func (c *PumpComponent) Name() string {
-	return ComponentPump
-}
-
-// Instances implements Component interface.
-func (c *PumpComponent) Instances() []Instance {
-	ins := make([]Instance, 0, len(c.PumpServers))
-	for _, s := range c.PumpServers {
-		ins = append(ins, &instance{
-			InstanceSpec: s,
-			name:         c.Name(),
-			host:         s.Host,
-			port:         s.Port,
-			sshp:         s.SSHPort,
-			topo:         c.Specification,
-
-			usedPorts: []int{
-				s.Port,
-			},
-			usedDirs: []string{
-				s.DeployDir,
-				s.DataDir,
-			},
-			statusFn: func(_ ...string) string {
-				return "N/A"
-			},
-		})
-	}
-	return ins
-}
-
-// DrainerComponent represents Drainer component.
-type DrainerComponent struct{ *Specification }
-
-// Name implements Component interface.
-func (c *DrainerComponent) Name() string {
-	return ComponentDrainer
-}
-
-// Instances implements Component interface.
-func (c *DrainerComponent) Instances() []Instance {
-	ins := make([]Instance, 0, len(c.Drainers))
-	for _, s := range c.Drainers {
-		ins = append(ins, &instance{
-			InstanceSpec: s,
-			name:         c.Name(),
-			host:         s.Host,
-			port:         s.Port,
-			sshp:         s.SSHPort,
-			topo:         c.Specification,
-
-			usedPorts: []int{
-				s.Port,
-			},
-			usedDirs: []string{
-				s.DeployDir,
-				s.DataDir,
-			},
-			statusFn: func(_ ...string) string {
-				return "N/A"
-			},
-		})
-	}
-	return ins
 }
 
 // MonitorComponent represents Monitor component.

--- a/pkg/meta/pump.go
+++ b/pkg/meta/pump.go
@@ -1,0 +1,97 @@
+package meta
+
+import (
+	"fmt"
+	"path/filepath"
+	"strconv"
+
+	"github.com/pingcap-incubator/tiops/pkg/executor"
+	"github.com/pingcap-incubator/tiops/pkg/template/config"
+	"github.com/pingcap-incubator/tiops/pkg/template/scripts"
+)
+
+// PumpComponent represents Pump component.
+type PumpComponent struct{ *Specification }
+
+// Name implements Component interface.
+func (c *PumpComponent) Name() string {
+	return ComponentPump
+}
+
+// Instances implements Component interface.
+func (c *PumpComponent) Instances() []Instance {
+	ins := make([]Instance, 0, len(c.PumpServers))
+	for _, s := range c.PumpServers {
+		ins = append(ins, &PumpInstance{instance{
+			InstanceSpec: s,
+			name:         c.Name(),
+			host:         s.Host,
+			port:         s.Port,
+			sshp:         s.SSHPort,
+			topo:         c.Specification,
+
+			usedPorts: []int{
+				s.Port,
+			},
+			usedDirs: []string{
+				s.DeployDir,
+				s.DataDir,
+			},
+			statusFn: func(_ ...string) string {
+				return "N/A"
+			},
+		}})
+	}
+	return ins
+}
+
+// PumpInstance represent the Pump instance.
+type PumpInstance struct {
+	instance
+}
+
+// InitConfig implements Instance interface.
+func (i *PumpInstance) InitConfig(e executor.TiOpsExecutor, user, cacheDir, deployDir string) error {
+	if err := i.instance.InitConfig(e, user, cacheDir, deployDir); err != nil {
+		return err
+	}
+
+	// transfer run script
+	ends := []*scripts.PDScript{}
+	for _, spec := range i.instance.topo.PDServers {
+		ends = append(ends, scripts.NewPDScript(spec.Name, spec.Host, spec.DeployDir, spec.DataDir))
+	}
+
+	cfg := scripts.NewPumpScript(
+		i.GetHost()+":"+strconv.Itoa(i.GetPort()),
+		i.GetHost(),
+		deployDir,
+		filepath.Join(deployDir, "data"),
+	).AppendEndpoints(ends...)
+
+	fp := filepath.Join(cacheDir, fmt.Sprintf("run_pump_%s_%d.sh", i.GetHost(), i.GetPort()))
+
+	if err := cfg.ConfigToFile(fp); err != nil {
+		return err
+	}
+	dst := filepath.Join(deployDir, "scripts", "run_pump.sh")
+	if err := e.Transfer(fp, dst); err != nil {
+		return err
+	}
+
+	if _, _, err := e.Execute("chmod +x "+dst, false); err != nil {
+		return err
+	}
+
+	// transfer config
+	fp = filepath.Join(cacheDir, fmt.Sprintf("pump_%s.toml", i.GetHost()))
+	if err := config.NewPumpConfig().ConfigToFile(fp); err != nil {
+		return err
+	}
+	dst = filepath.Join(deployDir, "conf", "pump.toml")
+	if err := e.Transfer(fp, dst); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/meta/topology.go
+++ b/pkg/meta/topology.go
@@ -243,6 +243,7 @@ type TopologyGlobalOptions struct {
 	SSHPort int `yaml:"ssh_port,omitempty" default:"22"`
 }
 
+// MonitoredOptions represents the options of monitored server.
 type MonitoredOptions struct {
 	DeployDir            string `yaml:"deploy_dir,omitempty" default:"monitored"`
 	DataDir              string `yaml:"data_dir,omitempty"  default:"monitored/data"`

--- a/pkg/template/config/drainer.go
+++ b/pkg/template/config/drainer.go
@@ -1,0 +1,55 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"io/ioutil"
+	"os"
+	"path"
+
+	"github.com/pingcap-incubator/tiup/pkg/localdata"
+)
+
+// DrainerConfig represent the data to generate Drainer config
+type DrainerConfig struct{}
+
+// NewDrainerConfig returns a DrainerConfig
+func NewDrainerConfig() *DrainerConfig {
+	return &DrainerConfig{}
+}
+
+// Config read ${localdata.EnvNameComponentInstallDir}/templates/config/drainer.yml
+// and generate the config by ConfigWithTemplate
+func (c *DrainerConfig) Config() ([]byte, error) {
+	fp := path.Join(os.Getenv(localdata.EnvNameComponentInstallDir), "templates", "config", "drainer.toml")
+	tpl, err := ioutil.ReadFile(fp)
+	if err != nil {
+		return nil, err
+	}
+	return c.ConfigWithTemplate(string(tpl))
+}
+
+// ConfigToFile write config content to specific path
+func (c *DrainerConfig) ConfigToFile(file string) error {
+	config, err := c.Config()
+	if err != nil {
+		return err
+	}
+	return ioutil.WriteFile(file, config, 0755)
+}
+
+// ConfigWithTemplate generate the Drainer config content by tpl
+func (c *DrainerConfig) ConfigWithTemplate(tpl string) ([]byte, error) {
+	return []byte(tpl), nil
+}

--- a/pkg/template/config/pump.go
+++ b/pkg/template/config/pump.go
@@ -1,0 +1,55 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"io/ioutil"
+	"os"
+	"path"
+
+	"github.com/pingcap-incubator/tiup/pkg/localdata"
+)
+
+// PumpConfig represent the data to generate Pump config
+type PumpConfig struct{}
+
+// NewPumpConfig returns a PumpConfig
+func NewPumpConfig() *PumpConfig {
+	return &PumpConfig{}
+}
+
+// Config read ${localdata.EnvNameComponentInstallDir}/templates/config/pump.yml
+// and generate the config by ConfigWithTemplate
+func (c *PumpConfig) Config() ([]byte, error) {
+	fp := path.Join(os.Getenv(localdata.EnvNameComponentInstallDir), "templates", "config", "pump.toml")
+	tpl, err := ioutil.ReadFile(fp)
+	if err != nil {
+		return nil, err
+	}
+	return c.ConfigWithTemplate(string(tpl))
+}
+
+// ConfigToFile write config content to specific path
+func (c *PumpConfig) ConfigToFile(file string) error {
+	config, err := c.Config()
+	if err != nil {
+		return err
+	}
+	return ioutil.WriteFile(file, config, 0755)
+}
+
+// ConfigWithTemplate generate the Pump config content by tpl
+func (c *PumpConfig) ConfigWithTemplate(tpl string) ([]byte, error) {
+	return []byte(tpl), nil
+}

--- a/pkg/template/scripts/drainer.go
+++ b/pkg/template/scripts/drainer.go
@@ -73,26 +73,35 @@ func (c *DrainerScript) AppendEndpoints(ends ...*PDScript) *DrainerScript {
 
 // Config read ${localdata.EnvNameComponentInstallDir}/templates/scripts/run_drainer.sh.tpl as template
 // and generate the config by ConfigWithTemplate
-func (c *DrainerScript) Config() (string, error) {
+func (c *DrainerScript) Config() ([]byte, error) {
 	fp := path.Join(os.Getenv(localdata.EnvNameComponentInstallDir), "templates", "scripts", "run_drainer.sh.tpl")
 	tpl, err := ioutil.ReadFile(fp)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	return c.ConfigWithTemplate(string(tpl))
 }
 
+// ConfigToFile write config content to specific file.
+func (c *DrainerScript) ConfigToFile(file string) error {
+	config, err := c.Config()
+	if err != nil {
+		return err
+	}
+	return ioutil.WriteFile(file, config, 0755)
+}
+
 // ConfigWithTemplate generate the Drainer config content by tpl
-func (c *DrainerScript) ConfigWithTemplate(tpl string) (string, error) {
+func (c *DrainerScript) ConfigWithTemplate(tpl string) ([]byte, error) {
 	tmpl, err := template.New("Drainer").Parse(tpl)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
 	content := bytes.NewBufferString("")
 	if err := tmpl.Execute(content, c); err != nil {
-		return "", err
+		return nil, err
 	}
 
-	return content.String(), nil
+	return content.Bytes(), nil
 }

--- a/templates/config/drainer.toml
+++ b/templates/config/drainer.toml
@@ -1,0 +1,158 @@
+# drainer Configuration.
+
+# addr (i.e. 'host:port') to listen on for drainer connections
+# will register this addr into etcd
+addr = "127.0.0.1:8249"
+
+# addr(i.e. 'host:port') to advertise to the public
+advertise-addr = ""
+
+# the interval time (in seconds) of detect pumps' status
+detect-interval = 10
+
+# drainer meta data directory path
+data-dir = "data.drainer"
+
+# a comma separated list of PD endpoints
+pd-urls = "http://127.0.0.1:2379"
+
+# Use the specified compressor to compress payload between pump and drainer
+compressor = ""
+
+#[security]
+# Path of file that contains list of trusted SSL CAs for connection with cluster components.
+# ssl-ca = "/path/to/ca.pem"
+# Path of file that contains X509 certificate in PEM format for connection with cluster components.
+# ssl-cert = "/path/to/pump.pem"
+# Path of file that contains X509 key in PEM format for connection with cluster components.
+# ssl-key = "/path/to/pump-key.pem"
+
+# syncer Configuration.
+[syncer]
+
+# Assume the upstream sql-mode.
+# If this is setted , will use the same sql-mode to parse DDL statment, and set the same sql-mode at downstream when db-type is mysql.
+# If this is not setted, it will not set any sql-mode.
+# sql-mode = "STRICT_TRANS_TABLES,NO_ENGINE_SUBSTITUTION"
+
+# number of binlog events in a transaction batch
+txn-batch = 20
+
+# sync ddl to downstream db or not
+sync-ddl = true
+
+# This variable works in dual-a. if it is false, the upstream data will all be synchronized to the downstream, except for the filtered table.
+# If it is true, the channel value is set at the same time, and the upstream starts with the mark table ID updated, and the channel ID is the same as its channel ID.
+# this part of data will not be synchronized to the downstream. Therefore, in dual-a scenario,both sides Channel id also needs to be set to the same value
+loopback-control = false
+
+# When loopback control is turned on, the channel ID will work.
+# In the dual-a scenario, the channel ID synchronized from the downstream to the upstream and the channel ID synchronized from
+# the upstream to the downstream need to be set to the same value to avoid loopback synchronization
+channel-id = 1
+
+# work count to execute binlogs
+# if the latency between drainer and downstream(mysql or tidb) are too high, you might want to increase this
+# to get higher throughput by higher concurrent write to the downstream
+worker-count = 16
+
+# enable-dispatch = true
+
+# safe mode will split update to delete and insert
+safe-mode = false
+
+# downstream storage, equal to --dest-db-type
+# valid values are "mysql", "file", "tidb", "kafka"
+db-type = "mysql"
+
+# ignore syncing the txn with specified commit ts to downstream
+ignore-txn-commit-ts = []
+
+# disable sync these schema
+ignore-schemas = "INFORMATION_SCHEMA,PERFORMANCE_SCHEMA,mysql"
+
+##replicate-do-db priority over replicate-do-table if have same db name
+##and we support regex expression , start with '~' declare use regex expression.
+#
+#replicate-do-db = ["~^b.*","s1"]
+
+[syncer.relay]
+# directory of relay logs. Empty string indicates disabling relay log.
+# relay log works only if the downstream is TiDB/MySQL.
+# log-dir = ""
+# max file size of each relay log
+# max-file-size = 10485760
+
+#[[syncer.replicate-do-table]]
+#db-name ="test"
+#tbl-name = "log"
+
+#[[syncer.replicate-do-table]]
+#db-name ="test"
+#tbl-name = "~^a.*"
+
+# disable sync these table
+#[[syncer.ignore-table]]
+#db-name = "test"
+#tbl-name = "log"
+
+# the downstream mysql protocol database
+[syncer.to]
+host = "127.0.0.1"
+user = "root"
+password = ""
+# if encrypted_password is not empty, password will be ignored.
+encrypted_password = ""
+port = 3306
+# 1: SyncFullColumn, 2: SyncPartialColumn
+# when setting SyncPartialColumn drainer will allow the downstream schema
+# having more or less column numbers and relax sql mode by removing STRICT_TRANS_TABLES.
+# sync-mode = 1
+#
+# Uncomment this part if you need TLS to connecting downstream MySQL/TiDB.
+# You can only specified only `ssl-ca` if there is no client certificate and don't need server to authenticate client.
+# [syncer.to.security]
+# Path of file that contains list of trusted SSL CAs.
+# ssl-ca = "/path/to/ca.pem"
+# Path of file that contains X509 certificate in PEM format.
+# ssl-cert = "/path/to/drainer.pem"
+# Path of file that contains X509 key in PEM format.
+# ssl-key = "/path/to/drainer-key.pem"
+# The common name which is allowed to connection with cluster components.
+# cert-allowed-cn = ["binlog"]
+
+[syncer.to.checkpoint]
+# only support mysql or tidb now, you can uncomment this to control where the checkpoint is saved.
+# the default way how checkpoint is saved according to db-type is:
+# mysql/tidb -> the according downstream mysql/tidb
+# file/kafka -> file in `data-dir`
+# type = "mysql"
+# you can uncomment this to change the database to save checkpoint when the checkpoint type is mysql or tidb
+# schema = "tidb_binlog"
+# host = "127.0.0.1"
+# user = "root"
+# if encrypted_password is not empty, password will be ignored.
+# encrypted_password = ""
+# password = ""
+# port = 3306
+
+# Uncomment this if you want to use file as db-type.
+#[syncer.to]
+# directory to save binlog file, default same as data-dir(save checkpoint file) if this is not configured.
+# dir = "data.drainer"
+#
+# retention-time = 7
+
+
+# when db-type is kafka, you can uncomment this to config the down stream kafka, it will be the globle config kafka default
+#[syncer.to]
+# only need config one of zookeeper-addrs and kafka-addrs, will get kafka address if zookeeper-addrs is configed.
+# zookeeper-addrs = "127.0.0.1:2181"
+# kafka-addrs = "127.0.0.1:9092"
+# kafka-version = "0.8.2.0"
+# kafka-max-messages = 1024
+# kafka-client-id = "tidb_binlog"
+#
+# the topic name drainer will push msg, the default name is <cluster-id>_obinlog
+# be careful don't use the same name if run multi drainer instances
+# topic-name = ""

--- a/templates/config/pump.toml
+++ b/templates/config/pump.toml
@@ -1,0 +1,53 @@
+# pump Configuration.
+
+# addr(i.e. 'host:port') to listen on for client traffic
+addr = "127.0.0.1:8250"
+
+# addr(i.e. 'host:port') to advertise to the public
+advertise-addr = ""
+
+# a integer value to control expiry date of the binlog data, indicates for how long (in days) the binlog data would be stored. 
+# must bigger than 0
+gc = 7
+
+# path to the data directory of pump's data
+data-dir = "data.pump"
+
+# number of seconds between heartbeat ticks (in 2 seconds)
+heartbeat-interval = 2
+
+# a comma separated list of PD endpoints
+pd-urls = "http://127.0.0.1:2379"
+
+#[security]
+# Path of file that contains list of trusted SSL CAs for connection with cluster components.
+# ssl-ca = "/path/to/ca.pem"
+# Path of file that contains X509 certificate in PEM format for connection with cluster components.
+# ssl-cert = "/path/to/drainer.pem"
+# Path of file that contains X509 key in PEM format for connection with cluster components.
+# ssl-key = "/path/to/drainer-key.pem"
+# The common name which is allowed to connection with cluster components.
+# cert-allowed-cn = ["binlog"]
+#
+# [storage]
+# Set to `true` (default) for best reliability, which prevents data loss when there is a power failure.
+# sync-log = true
+
+# stop write when disk available space less then the configured size
+# 42 MB -> 42000000, 42 mib -> 44040192
+# default: 10 gib
+# stop-write-at-available-space = "10 gib"
+
+#
+# we suggest using the default config of the embedded LSM DB now, do not change it useless you know what you are doing
+# [storage.kv]
+# block-cache-capacity = 8388608
+# block-restart-interval = 16
+# block-size = 4096
+# compaction-L0-trigger = 8
+# compaction-table-size = 67108864
+# compaction-total-size = 536870912
+# compaction-total-size-multiplier = 8.0
+# write-buffer = 67108864
+# write-L0-pause-trigger = 24
+# write-L0-slowdown-trigger = 17

--- a/templates/scripts/run_drainer.sh.tpl
+++ b/templates/scripts/run_drainer.sh.tpl
@@ -11,9 +11,9 @@ cd "${DEPLOY_DIR}" || exit 1
 {{- define "PDList"}}
   {{- range $idx, $pd := .}}
     {{- if eq $idx 0}}
-      {{- $pd.Scheme}}://{{$pd.IP}}:{{$pd.PeerPort}}
+      {{- $pd.Scheme}}://{{$pd.IP}}:{{$pd.ClientPort}}
     {{- else -}}
-      ,{{- $pd.Scheme}}://{{$pd.IP}}:{{$pd.PeerPort}}
+      ,{{- $pd.Scheme}}://{{$pd.IP}}:{{$pd.ClientPort}}
     {{- end}}
   {{- end}}
 {{- end}}

--- a/templates/scripts/run_pd.sh.tpl
+++ b/templates/scripts/run_pd.sh.tpl
@@ -29,5 +29,5 @@ exec bin/pd-server \
     --advertise-peer-urls="{{.Scheme}}://{{.IP}}:{{.PeerPort}}" \
     --data-dir="{{.DataDir}}" \
     --initial-cluster="{{template "PDList" .Endpoints}}" \
-    --log-file="logs/pd.log" 2>> "logs/pd_stderr.log"
+    --log-file="log/pd.log" 2>> "log/pd_stderr.log"
   

--- a/templates/scripts/run_pd_scale.sh.tpl
+++ b/templates/scripts/run_pd_scale.sh.tpl
@@ -29,5 +29,5 @@ exec bin/pd-server \
     --advertise-peer-urls="{{.Scheme}}://{{.IP}}:{{.PeerPort}}" \
     --data-dir="{{.DataDir}}" \
     --join="{{template "PDList" .Endpoints}}" \
-    --log-file="logs/pd.log" 2>> "logs/pd_stderr.log"
+    --log-file="log/pd.log" 2>> "log/pd_stderr.log"
   

--- a/templates/scripts/run_pump.sh.tpl
+++ b/templates/scripts/run_pump.sh.tpl
@@ -11,9 +11,9 @@ cd "${DEPLOY_DIR}" || exit 1
 {{- define "PDList"}}
   {{- range $idx, $pd := .}}
     {{- if eq $idx 0}}
-      {{- $pd.Scheme}}://{{$pd.IP}}:{{$pd.PeerPort}}
+      {{- $pd.Scheme}}://{{$pd.IP}}:{{$pd.ClientPort}}
     {{- else -}}
-      ,{{- $pd.Scheme}}://{{$pd.IP}}:{{$pd.PeerPort}}
+      ,{{- $pd.Scheme}}://{{$pd.IP}}:{{$pd.ClientPort}}
     {{- end}}
   {{- end}}
 {{- end}}
@@ -25,7 +25,7 @@ exec bin/pump \
 {{- end}}
     --node-id="{{.NodeID}}" \
     --addr="0.0.0.0:{{.Port}}" \
-    --advertise-addr="{{.IP}}:{{.Port}}" \
+    --advertise-addr="{{.Host}}:{{.Port}}" \
     --pd-urls="{{template "PDList" .Endpoints}}" \
     --data-dir="{{.DataDir}}" \
     --log-file="log/pump.log" \

--- a/templates/scripts/run_tidb.sh.tpl
+++ b/templates/scripts/run_tidb.sh.tpl
@@ -27,5 +27,5 @@ exec bin/tidb-server \
     --advertise-address="{{.IP}}" \
     --store="tikv" \
     --path="{{template "PDList" .Endpoints}}" \
-    --log-slow-query="logs/tidb_slow_query.log" \
-    --log-file="logs/tidb.log" 2>> "logs/tidb_stderr.log"
+    --log-slow-query="log/tidb_slow_query.log" \
+    --log-file="log/tidb.log" 2>> "log/tidb_stderr.log"

--- a/templates/scripts/run_tikv.sh.tpl
+++ b/templates/scripts/run_tikv.sh.tpl
@@ -30,5 +30,5 @@ exec bin/tikv-server \
     --status-addr "{{.IP}}:{{.StatusPort}}" \
     --pd "{{template "PDList" .Endpoints}}" \
     --data-dir "{{.DataDir}}" \
-    --config config/tikv.toml \
-    --log-file "logs/tikv.log" 2>> "logs/tikv_stderr.log"
+    --config conf/tikv.toml \
+    --log-file "log/tikv.log" 2>> "log/tikv_stderr.log"

--- a/tests/topo_binlog.yaml
+++ b/tests/topo_binlog.yaml
@@ -1,0 +1,21 @@
+tidb_servers:
+  - host: 172.19.0.101
+  - host: 172.19.0.102
+
+pd_servers:
+  - host: 172.19.0.103
+  - host: 172.19.0.104
+  - host: 172.19.0.105
+
+tikv_servers:
+  - host: 172.19.0.103
+  - host: 172.19.0.104
+  - host: 172.19.0.105
+
+pump_servers:
+  - host: 172.19.0.103
+  - host: 172.19.0.104
+  - host: 172.19.0.105
+
+drainer_servers:
+  # - host: 172.19.0.101


### PR DESCRIPTION
- Make pump&drainer can deploy&started
- support set env TIUP_MIRRORS to mount it and use in control for
avoiding download components.
    * example: TIUP_MIRRORS=/Users/huangjiahao/local-mirrors
    TIOPS_ROOT=/Users/huangjiahao/go/src/github.com/pingcap-incubator/tiops
    ./up.sh --dev
 - unify using log/ and conf/ for deploy


Note it only make pump and drainer can be deployed and start, there 's more work need  to do like scale in and out.