### PR TITLE
detect port/directory conflict when scale-out and fix some other trivial bugs.

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -87,7 +87,7 @@ func getComponentVersion(comp, version string) repository.Version {
 }
 
 func deploy(name, version, topoFile string, opt deployOptions) error {
-	if utils.IsExist(meta.ClusterPath(name)) {
+	if utils.IsExist(meta.ClusterPath(name, meta.MetaFileName)) {
 		return errors.Errorf("cluster name '%s' exists, please choose another cluster name", name)
 	}
 
@@ -100,9 +100,6 @@ func deploy(name, version, topoFile string, opt deployOptions) error {
 		return errors.Trace(err)
 	}
 	if err := os.MkdirAll(meta.ClusterPath(name), 0755); err != nil {
-		return err
-	}
-	if err := ioutil.WriteFile(meta.ClusterPath(name, "topology.yaml"), yamlFile, 0664); err != nil {
 		return err
 	}
 

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -14,19 +14,18 @@
 package cmd
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/pingcap-incubator/tiops/pkg/meta"
 	"github.com/pingcap-incubator/tiops/pkg/task"
+	tiopsutils "github.com/pingcap-incubator/tiops/pkg/utils"
 	"github.com/pingcap-incubator/tiup/pkg/repository"
 	"github.com/pingcap-incubator/tiup/pkg/set"
 	"github.com/pingcap-incubator/tiup/pkg/utils"
 	"github.com/pingcap/errors"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v2"
 )
 
 type componentInfo struct {
@@ -92,12 +91,8 @@ func deploy(clusterName, version, topoFile string, opt deployOptions) error {
 	}
 
 	var topo meta.TopologySpecification
-	yamlFile, err := ioutil.ReadFile(topoFile)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	if err = yaml.Unmarshal(yamlFile, &topo); err != nil {
-		return errors.Trace(err)
+	if err := tiopsutils.ParseYaml(topoFile, &topo); err != nil {
+		return err
 	}
 	if err := os.MkdirAll(meta.ClusterPath(clusterName), 0755); err != nil {
 		return err

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -52,7 +52,7 @@ func newDeploy() *cobra.Command {
 				return cmd.Help()
 			}
 			if len(opt.keyFile) == 0 && len(opt.password) == 0 {
-				return errors.New("password and key need to specify at least one")
+				return errors.New("--password and --key need to specify at least one")
 			}
 			return deploy(args[0], args[1], args[2], opt)
 		},

--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -17,7 +17,6 @@ import (
 	"os"
 
 	"github.com/pingcap-incubator/tiops/pkg/log"
-
 	"github.com/pingcap-incubator/tiops/pkg/meta"
 	operator "github.com/pingcap-incubator/tiops/pkg/operation"
 	"github.com/pingcap-incubator/tiops/pkg/task"

--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -14,15 +14,18 @@
 package cmd
 
 import (
+	"os"
+
+	"github.com/pingcap-incubator/tiops/pkg/log"
+
 	"github.com/pingcap-incubator/tiops/pkg/meta"
 	operator "github.com/pingcap-incubator/tiops/pkg/operation"
 	"github.com/pingcap-incubator/tiops/pkg/task"
+	"github.com/pingcap/errors"
 	"github.com/spf13/cobra"
 )
 
 func newDestroyCmd() *cobra.Command {
-	var options operator.Options
-
 	cmd := &cobra.Command{
 		Use:   "destroy <cluster-name>",
 		Short: "Destroy a specified cluster",
@@ -31,20 +34,28 @@ func newDestroyCmd() *cobra.Command {
 				return cmd.Help()
 			}
 
-			metadata, err := meta.ClusterMetadata(args[0])
+			clusterName := args[0]
+			metadata, err := meta.ClusterMetadata(clusterName)
 			if err != nil {
 				return err
 			}
 			t := task.NewBuilder().
 				SSHKeySet(
-					meta.ClusterPath(args[0], "ssh", "id_rsa"),
-					meta.ClusterPath(args[0], "ssh", "id_rsa.pub")).
+					meta.ClusterPath(clusterName, "ssh", "id_rsa"),
+					meta.ClusterPath(clusterName, "ssh", "id_rsa.pub")).
 				ClusterSSH(metadata.Topology, metadata.User).
-				ClusterOperate(metadata.Topology, operator.StopOperation, options).
+				ClusterOperate(metadata.Topology, operator.StopOperation, operator.Options{}).
 				ClusterOperate(metadata.Topology, operator.DestroyOperation, operator.Options{}).
 				Build()
 
-			return t.Execute(task.NewContext())
+			if err := t.Execute(task.NewContext()); err != nil {
+				return err
+			}
+			if err := os.RemoveAll(meta.ClusterPath(clusterName)); err != nil {
+				return errors.Trace(err)
+			}
+			log.Infof("Destroy cluster `%s` successfully", clusterName)
+			return nil
 		},
 	}
 	return cmd

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -18,6 +18,8 @@ import (
 	"os"
 
 	"github.com/fatih/color"
+	"github.com/pingcap-incubator/tiops/pkg/flags"
+
 	"github.com/pingcap-incubator/tiops/pkg/meta"
 	"github.com/pingcap-incubator/tiops/pkg/version"
 	tiupmeta "github.com/pingcap-incubator/tiup/pkg/meta"
@@ -72,8 +74,13 @@ func init() {
 
 // Execute executes the root command
 func Execute() {
+	flags.ShowBacktrace = len(os.Getenv("TIUP_BACKTRACE")) > 0
 	if err := rootCmd.Execute(); err != nil {
-		fmt.Println(color.RedString("Error: %+v", err))
+		if flags.ShowBacktrace {
+			fmt.Println(color.RedString("Error: %+v", err))
+		} else {
+			fmt.Println(color.RedString("Error: %v", err))
+		}
 		os.Exit(1)
 	}
 }

--- a/pkg/flags/debug.go
+++ b/pkg/flags/debug.go
@@ -1,0 +1,19 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package flags
+
+// Global flags
+var (
+	ShowBacktrace = false
+)

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -1,0 +1,40 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log
+
+import (
+	"fmt"
+
+	"github.com/fatih/color"
+)
+
+// Debugf output the debug message to console
+func Debugf(format string, args ...interface{}) {
+	fmt.Println(color.CyanString(format, args...))
+}
+
+// Infof output the log message to console
+func Infof(format string, args ...interface{}) {
+	fmt.Println(color.GreenString(format, args...))
+}
+
+// Warnf output the warning message to console
+func Warnf(format string, args ...interface{}) {
+	fmt.Println(color.YellowString(format, args...))
+}
+
+// Errorf output the error message to console
+func Errorf(format string, args ...interface{}) {
+	fmt.Println(color.RedString(format, args...))
+}

--- a/pkg/meta/logic.go
+++ b/pkg/meta/logic.go
@@ -600,3 +600,19 @@ func (topo *Specification) ComponentsByStartOrder() (comps []Component) {
 	comps = append(comps, &AlertmanagerComponent{topo})
 	return
 }
+
+// IterComponent iterates all components in component starting order
+func (topo *Specification) IterComponent(fn func(comp Component)) {
+	for _, comp := range topo.ComponentsByStartOrder() {
+		fn(comp)
+	}
+}
+
+// IterInstance iterates all instances in component starting order
+func (topo *Specification) IterInstance(fn func(instance Instance)) {
+	for _, comp := range topo.ComponentsByStartOrder() {
+		for _, inst := range comp.Instances() {
+			fn(inst)
+		}
+	}
+}

--- a/pkg/meta/topology.go
+++ b/pkg/meta/topology.go
@@ -299,12 +299,12 @@ func (topo *TopologySpecification) UnmarshalYAML(unmarshal func(interface{}) err
 		return err
 	}
 
-	return topo.validate()
+	return topo.Validate()
 }
 
-// validate validates the topology specification and produce error if
-// the specification invalid
-func (topo *TopologySpecification) validate() error {
+// Validate validates the topology specification and produce error if the
+// specification invalid (e.g: port conflicts or directory conflicts)
+func (topo *TopologySpecification) Validate() error {
 	findField := func(v reflect.Value, fieldName string) (int, bool) {
 		for i := 0; i < v.NumField(); i++ {
 			if v.Type().Field(i).Name == fieldName {
@@ -459,14 +459,16 @@ func (topo *TopologySpecification) GetPDList() []string {
 // Merge returns a new TopologySpecification which sum old ones
 func (topo *TopologySpecification) Merge(that *TopologySpecification) *TopologySpecification {
 	return &TopologySpecification{
-		TiDBServers:  append(topo.TiDBServers, that.TiDBServers...),
-		TiKVServers:  append(topo.TiKVServers, that.TiKVServers...),
-		PDServers:    append(topo.PDServers, that.PDServers...),
-		PumpServers:  append(topo.PumpServers, that.PumpServers...),
-		Drainers:     append(topo.Drainers, that.Drainers...),
-		Monitors:     append(topo.Monitors, that.Monitors...),
-		Grafana:      append(topo.Grafana, that.Grafana...),
-		Alertmanager: append(topo.Alertmanager, that.Alertmanager...),
+		GlobalOptions:    topo.GlobalOptions,
+		MonitoredOptions: topo.MonitoredOptions,
+		TiDBServers:      append(topo.TiDBServers, that.TiDBServers...),
+		TiKVServers:      append(topo.TiKVServers, that.TiKVServers...),
+		PDServers:        append(topo.PDServers, that.PDServers...),
+		PumpServers:      append(topo.PumpServers, that.PumpServers...),
+		Drainers:         append(topo.Drainers, that.Drainers...),
+		Monitors:         append(topo.Monitors, that.Monitors...),
+		Grafana:          append(topo.Grafana, that.Grafana...),
+		Alertmanager:     append(topo.Alertmanager, that.Alertmanager...),
 	}
 }
 

--- a/pkg/meta/topology.go
+++ b/pkg/meta/topology.go
@@ -99,7 +99,7 @@ func (s TiDBSpec) Status(pdList ...string) string {
 	// body doesn't have any status section needed
 	body, err := client.Get(url)
 	if err != nil {
-		return "ERR"
+		return "N/A"
 	}
 	if body == nil {
 		return "Down"
@@ -133,7 +133,7 @@ func (s TiKVSpec) Status(pdList ...string) string {
 	pdapi := api.NewPDClient(pdList[0], statusQueryTimeout, nil)
 	stores, err := pdapi.GetStores()
 	if err != nil {
-		return "ERR"
+		return "N/A"
 	}
 
 	name := fmt.Sprintf("%s:%d", s.Host, s.Port)
@@ -169,13 +169,13 @@ func (s PDSpec) Status(pdList ...string) string {
 		statusQueryTimeout, nil)
 	healths, err := pdapi.GetHealth()
 	if err != nil {
-		return "ERR"
+		return "N/A"
 	}
 
 	// find leader node
 	leader, err := pdapi.GetLeader()
 	if err != nil {
-		return "ERR"
+		return "N/A"
 	}
 
 	for _, member := range healths.Healths {

--- a/pkg/operation/scale_in.go
+++ b/pkg/operation/scale_in.go
@@ -17,6 +17,8 @@ import (
 	"io"
 	"time"
 
+	"github.com/pingcap-incubator/tiops/pkg/log"
+
 	"github.com/pingcap-incubator/tiops/pkg/api"
 	"github.com/pingcap-incubator/tiops/pkg/meta"
 	"github.com/pingcap-incubator/tiup/pkg/set"
@@ -105,6 +107,9 @@ func ScaleIn(
 				if err := DestroyComponent(getter, w, []meta.Instance{instance}); err != nil {
 					return errors.Annotatef(err, "failed to destroy %s", component.Name())
 				}
+			} else {
+				log.Warnf("The component `%s` will be destroyed in background, maybe exists in several minutes or hours",
+					component.Name())
 			}
 		}
 	}

--- a/pkg/operation/scale_in.go
+++ b/pkg/operation/scale_in.go
@@ -17,9 +17,8 @@ import (
 	"io"
 	"time"
 
-	"github.com/pingcap-incubator/tiops/pkg/log"
-
 	"github.com/pingcap-incubator/tiops/pkg/api"
+	"github.com/pingcap-incubator/tiops/pkg/log"
 	"github.com/pingcap-incubator/tiops/pkg/meta"
 	"github.com/pingcap-incubator/tiup/pkg/set"
 	"github.com/pingcap/errors"

--- a/pkg/task/action.go
+++ b/pkg/task/action.go
@@ -77,7 +77,7 @@ func (c *ClusterOperate) Execute(ctx *Context) error {
 
 // Rollback implements the Task interface
 func (c *ClusterOperate) Rollback(ctx *Context) error {
-	return ErrUnsupportRollback
+	return ErrUnsupportedRollback
 }
 
 // String implements the fmt.Stringer interface

--- a/pkg/task/copy_component.go
+++ b/pkg/task/copy_component.go
@@ -61,7 +61,7 @@ func (c *CopyComponent) Execute(ctx *Context) error {
 
 // Rollback implements the Task interface
 func (c *CopyComponent) Rollback(ctx *Context) error {
-	return ErrUnsupportRollback
+	return ErrUnsupportedRollback
 }
 
 // String implements the fmt.Stringer interface

--- a/pkg/task/copy_file.go
+++ b/pkg/task/copy_file.go
@@ -43,7 +43,7 @@ func (c *CopyFile) Execute(ctx *Context) error {
 
 // Rollback implements the Task interface
 func (c *CopyFile) Rollback(ctx *Context) error {
-	return ErrUnsupportRollback
+	return ErrUnsupportedRollback
 }
 
 // String implements the fmt.Stringer interface

--- a/pkg/task/env_init.go
+++ b/pkg/task/env_init.go
@@ -71,7 +71,7 @@ func (e *EnvInit) Execute(ctx *Context) error {
 
 // Rollback implements the Task interface
 func (e *EnvInit) Rollback(ctx *Context) error {
-	return ErrUnsupportRollback
+	return ErrUnsupportedRollback
 }
 
 // String implements the fmt.Stringer interface

--- a/pkg/task/init_config.go
+++ b/pkg/task/init_config.go
@@ -47,7 +47,7 @@ func (c *InitConfig) Execute(ctx *Context) error {
 
 // Rollback implements the Task interface
 func (c *InitConfig) Rollback(ctx *Context) error {
-	return ErrUnsupportRollback
+	return ErrUnsupportedRollback
 }
 
 // String implements the fmt.Stringer interface

--- a/pkg/task/mkdir.go
+++ b/pkg/task/mkdir.go
@@ -43,7 +43,7 @@ func (m *Mkdir) Execute(ctx *Context) error {
 
 // Rollback implements the Task interface
 func (m *Mkdir) Rollback(ctx *Context) error {
-	return ErrUnsupportRollback
+	return ErrUnsupportedRollback
 }
 
 // String implements the fmt.Stringer interface

--- a/pkg/task/monitored_config.go
+++ b/pkg/task/monitored_config.go
@@ -36,7 +36,7 @@ func (m *MonitoredConfig) Execute(ctx *Context) error {
 
 // Rollback implements the Task interface
 func (m *MonitoredConfig) Rollback(ctx *Context) error {
-	return ErrUnsupportRollback
+	return ErrUnsupportedRollback
 }
 
 // String implements the fmt.Stringer interface

--- a/pkg/task/monitored_config.go
+++ b/pkg/task/monitored_config.go
@@ -16,6 +16,8 @@ package task
 import (
 	"fmt"
 
+	"github.com/pingcap-incubator/tiops/pkg/log"
+
 	"github.com/pingcap-incubator/tiops/pkg/meta"
 )
 
@@ -29,7 +31,7 @@ type MonitoredConfig struct {
 
 // Execute implements the Task interface
 func (m *MonitoredConfig) Execute(ctx *Context) error {
-	ctx.Warnf("MonitoredConfig not implement")
+	log.Warnf("MonitoredConfig not implement")
 	return nil
 }
 

--- a/pkg/task/monitored_config.go
+++ b/pkg/task/monitored_config.go
@@ -17,7 +17,6 @@ import (
 	"fmt"
 
 	"github.com/pingcap-incubator/tiops/pkg/log"
-
 	"github.com/pingcap-incubator/tiops/pkg/meta"
 )
 

--- a/pkg/task/scale_config.go
+++ b/pkg/task/scale_config.go
@@ -47,7 +47,7 @@ func (c *ScaleConfig) Execute(ctx *Context) error {
 
 // Rollback implements the Task interface
 func (c *ScaleConfig) Rollback(ctx *Context) error {
-	return ErrUnsupportRollback
+	return ErrUnsupportedRollback
 }
 
 // String implements the fmt.Stringer interface

--- a/pkg/task/shell.go
+++ b/pkg/task/shell.go
@@ -53,7 +53,7 @@ func (m *Shell) Execute(ctx *Context) error {
 
 // Rollback implements the Task interface
 func (m *Shell) Rollback(ctx *Context) error {
-	return ErrUnsupportRollback
+	return ErrUnsupportedRollback
 }
 
 // String implements the fmt.Stringer interface

--- a/pkg/task/task.go
+++ b/pkg/task/task.go
@@ -19,11 +19,9 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/pingcap-incubator/tiops/pkg/log"
-
-	"github.com/pingcap-incubator/tiops/pkg/flags"
-
 	"github.com/pingcap-incubator/tiops/pkg/executor"
+	"github.com/pingcap-incubator/tiops/pkg/flags"
+	"github.com/pingcap-incubator/tiops/pkg/log"
 	"github.com/pingcap-incubator/tiup/pkg/repository"
 )
 

--- a/pkg/task/task.go
+++ b/pkg/task/task.go
@@ -19,6 +19,8 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/pingcap-incubator/tiops/pkg/flags"
+
 	"github.com/fatih/color"
 	"github.com/pingcap-incubator/tiops/pkg/executor"
 	"github.com/pingcap-incubator/tiup/pkg/repository"
@@ -193,7 +195,11 @@ type errs []error
 func (es errs) Error() string {
 	ss := make([]string, 0, len(es))
 	for _, e := range es {
-		ss = append(ss, fmt.Sprintf("%+v", e))
+		if flags.ShowBacktrace {
+			ss = append(ss, fmt.Sprintf("%+v", e))
+		} else {
+			ss = append(ss, fmt.Sprintf("%v", e))
+		}
 	}
 	return strings.Join(ss, "\n")
 }

--- a/pkg/task/task.go
+++ b/pkg/task/task.go
@@ -26,8 +26,8 @@ import (
 )
 
 var (
-	// ErrUnsupportRollback means the task do not support rollback.
-	ErrUnsupportRollback = stderrors.New("unsupport rollback")
+	// ErrUnsupportedRollback means the task do not support rollback.
+	ErrUnsupportedRollback = stderrors.New("unsupported rollback")
 	// ErrNoExecutor means can get the executor.
 	ErrNoExecutor = stderrors.New("no executor")
 )

--- a/pkg/task/task.go
+++ b/pkg/task/task.go
@@ -19,9 +19,10 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/pingcap-incubator/tiops/pkg/log"
+
 	"github.com/pingcap-incubator/tiops/pkg/flags"
 
-	"github.com/fatih/color"
 	"github.com/pingcap-incubator/tiops/pkg/executor"
 	"github.com/pingcap-incubator/tiup/pkg/repository"
 )
@@ -128,26 +129,6 @@ func (ctx *Context) SetManifest(comp string, m *repository.VersionManifest) {
 	return
 }
 
-// Debugf output the debug message to console
-func (ctx *Context) Debugf(format string, args ...interface{}) {
-	fmt.Println(color.CyanString(format, args...))
-}
-
-// Infof output the log message to console
-func (ctx *Context) Infof(format string, args ...interface{}) {
-	fmt.Println(color.GreenString(format, args...))
-}
-
-// Warnf output the warning message to console
-func (ctx *Context) Warnf(format string, args ...interface{}) {
-	fmt.Println(color.YellowString(format, args...))
-}
-
-// Errorf output the error message to console
-func (ctx *Context) Errorf(format string, args ...interface{}) {
-	fmt.Println(color.RedString(format, args...))
-}
-
 func isSingleTask(t Task) bool {
 	_, isS := t.(Serial)
 	_, isP := t.(Parallel)
@@ -158,7 +139,7 @@ func isSingleTask(t Task) bool {
 func (s Serial) Execute(ctx *Context) error {
 	for _, t := range s {
 		if isSingleTask(t) {
-			ctx.Infof("+ [ Serial ] - %s", t.String())
+			log.Infof("+ [ Serial ] - %s", t.String())
 		}
 		err := t.Execute(ctx)
 		if err != nil {
@@ -214,7 +195,7 @@ func (pt Parallel) Execute(ctx *Context) error {
 		go func(t Task) {
 			defer wg.Done()
 			if isSingleTask(t) {
-				ctx.Debugf("+ [Parallel] - %s", t.String())
+				log.Debugf("+ [Parallel] - %s", t.String())
 			}
 			err := t.Execute(ctx)
 			if err != nil {


### PR DESCRIPTION
Signed-off-by: Lonng <heng@lonng.org>

This PR tries to resolve the following issues:
1. support TIUP_BACKTRACE environment variable to control where show backtrace.
2. change the policy to detect cluster name conflicts
3. show N/A if cannot fetch the status of specific component
4. fix scale-out conflicts and duplicated initial environment