### PR TITLE
deploy monitored relevant components when scale-out uninitialized host

### DIFF
--- a/pkg/task/builder.go
+++ b/pkg/task/builder.go
@@ -223,6 +223,12 @@ func (b *Builder) Parallel(tasks ...Task) *Builder {
 	return b
 }
 
+// Serial appends the tasks to the tail of queue
+func (b *Builder) Serial(tasks ...Task) *Builder {
+	b.tasks = append(b.tasks, tasks...)
+	return b
+}
+
 // Build returns a task that contains all tasks appended by previous operation
 func (b *Builder) Build() Task {
 	if len(b.tasks) == 1 {

--- a/pkg/task/download.go
+++ b/pkg/task/download.go
@@ -32,6 +32,13 @@ type Downloader struct {
 
 // Execute implements the Task interface
 func (d *Downloader) Execute(_ *Context) error {
+	if d.component == "" {
+		return errors.New("component name not specified")
+	}
+	if d.version.IsEmpty() {
+		return errors.Errorf("version not specified for component '%s'", d.component)
+	}
+
 	resName := fmt.Sprintf("%s-%s", d.component, d.version)
 	fileName := fmt.Sprintf("%s-linux-amd64.tar.gz", resName)
 	srcPath := meta.ProfilePath(meta.TiOpsPackageCacheDir, fileName)


### PR DESCRIPTION
Signed-off-by: Lonng <heng@lonng.org>

This PR separates the download and deploy tasks of monitored relevant components into the individual function to make `deploy` and `scale-out` reuse easily.