### PR TITLE
*: various fixes to work with imported clusters

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -35,6 +35,7 @@ type componentInfo struct {
 
 type deployOptions struct {
 	user       string // username to login to the SSH server
+	usePasswd  bool   // use password for authentication
 	password   string // password of the user
 	keyFile    string // path to the private key file
 	passphrase string // passphrase of the private key file
@@ -50,6 +51,9 @@ func newDeploy() *cobra.Command {
 			if len(args) != 3 {
 				return cmd.Help()
 			}
+			if opt.usePasswd {
+				opt.password = tiopsutils.GetPasswd("Password:")
+			}
 			if len(opt.keyFile) == 0 && len(opt.password) == 0 {
 				return errPasswordKeyAtLeastOne
 			}
@@ -60,7 +64,7 @@ func newDeploy() *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&opt.user, "user", "root", "Specify the system user name")
-	cmd.Flags().StringVar(&opt.password, "password", "", "Specify the password of system user")
+	cmd.Flags().BoolVar(&opt.usePasswd, "password", false, "Specify the password of system user")
 	cmd.Flags().StringVar(&opt.keyFile, "key", "", "Specify the key path of system user")
 	cmd.Flags().StringVar(&opt.passphrase, "passphrase", "", "Specify the passphrase of the key")
 

--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -14,12 +14,16 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
+	"strings"
 
+	"github.com/fatih/color"
 	"github.com/pingcap-incubator/tiops/pkg/log"
 	"github.com/pingcap-incubator/tiops/pkg/meta"
 	operator "github.com/pingcap-incubator/tiops/pkg/operation"
 	"github.com/pingcap-incubator/tiops/pkg/task"
+	"github.com/pingcap-incubator/tiops/pkg/utils"
 	tiuputils "github.com/pingcap-incubator/tiup/pkg/utils"
 	"github.com/pingcap/errors"
 	"github.com/spf13/cobra"
@@ -44,6 +48,19 @@ func newDestroyCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
+
+			promptMsg := fmt.Sprintf("This operation will destroy TiDB %s cluster %s and its data, do you want to continue?\n[Y]es/[N]o:",
+				color.HiYellowString(metadata.Version), color.HiYellowString(clusterName))
+			ans := utils.Prompt(promptMsg)
+			switch strings.ToLower(ans) {
+			case "y", "yes":
+				log.Infof("Destrying cluster...")
+			case "n", "no":
+				return errors.New("operation cancelled by user")
+			default:
+				return errors.New("unknown input, abort")
+			}
+
 			t := task.NewBuilder().
 				SSHKeySet(
 					meta.ClusterPath(clusterName, "ssh", "id_rsa"),

--- a/cmd/scale_in.go
+++ b/cmd/scale_in.go
@@ -68,6 +68,10 @@ func scaleIn(cluster string, options operator.Options) error {
 			if !strings.HasPrefix(deployDir, "/") {
 				deployDir = filepath.Join("/home/", metadata.User, deployDir)
 			}
+			dataDir := instance.DataDir()
+			if dataDir != "" && !strings.HasPrefix(dataDir, "/") {
+				dataDir = filepath.Join("/home/", metadata.User, dataDir)
+			}
 			logDir := instance.LogDir()
 			if !strings.HasPrefix(logDir, "/") {
 				logDir = filepath.Join("/home/", metadata.User, logDir)
@@ -77,6 +81,7 @@ func scaleIn(cluster string, options operator.Options) error {
 				metadata.User,
 				meta.DirPaths{
 					Deploy: deployDir,
+					Data:   dataDir,
 					Log:    logDir,
 				},
 			).Build()

--- a/cmd/scale_in.go
+++ b/cmd/scale_in.go
@@ -68,7 +68,18 @@ func scaleIn(cluster string, options operator.Options) error {
 			if !strings.HasPrefix(deployDir, "/") {
 				deployDir = filepath.Join("/home/", metadata.User, deployDir)
 			}
-			t := task.NewBuilder().InitConfig(cluster, instance, metadata.User, deployDir).Build()
+			logDir := instance.LogDir()
+			if !strings.HasPrefix(logDir, "/") {
+				logDir = filepath.Join("/home/", metadata.User, logDir)
+			}
+			t := task.NewBuilder().InitConfig(cluster,
+				instance,
+				metadata.User,
+				meta.DirPaths{
+					Deploy: deployDir,
+					Log:    logDir,
+				},
+			).Build()
 			regenConfigTasks = append(regenConfigTasks, t)
 		}
 	}

--- a/cmd/scale_out.go
+++ b/cmd/scale_out.go
@@ -142,6 +142,12 @@ func buildScaleOutTask(
 		if !strings.HasPrefix(deployDir, "/") {
 			deployDir = filepath.Join("/home/", metadata.User, deployDir)
 		}
+		// data dir would be empty for components which don't need it
+		dataDir := inst.DataDir()
+		if dataDir != "" && !strings.HasPrefix(dataDir, "/") {
+			dataDir = filepath.Join("/home/", metadata.User, dataDir)
+		}
+		// log dir will always be with values, but might not used by the component
 		logDir := inst.LogDir()
 		if !strings.HasPrefix(logDir, "/") {
 			logDir = filepath.Join("/home/", metadata.User, logDir)
@@ -154,6 +160,7 @@ func buildScaleOutTask(
 				filepath.Join(deployDir, "bin"),
 				filepath.Join(deployDir, "conf"),
 				filepath.Join(deployDir, "scripts"),
+				dataDir,
 				logDir).
 			CopyComponent(inst.ComponentName(), version, inst.GetHost(), deployDir).
 			ScaleConfig(clusterName,
@@ -162,6 +169,7 @@ func buildScaleOutTask(
 				metadata.User,
 				meta.DirPaths{
 					Deploy: deployDir,
+					Data:   dataDir,
 					Log:    logDir,
 				},
 			).Build()
@@ -178,6 +186,7 @@ func buildScaleOutTask(
 			UserSSH(inst.GetHost(), metadata.User).
 			InitConfig(clusterName, inst, metadata.User, meta.DirPaths{
 				Deploy: deployDir,
+				Data:   dataDir,
 				Log:    logDir,
 			}).
 			Build()

--- a/cmd/scale_out.go
+++ b/cmd/scale_out.go
@@ -181,6 +181,14 @@ func buildScaleOutTask(
 		if !strings.HasPrefix(deployDir, "/") {
 			deployDir = filepath.Join("/home/", metadata.User, deployDir)
 		}
+		dataDir := inst.DataDir()
+		if dataDir != "" && !strings.HasPrefix(dataDir, "/") {
+			dataDir = filepath.Join("/home/", metadata.User, dataDir)
+		}
+		logDir := inst.LogDir()
+		if !strings.HasPrefix(logDir, "/") {
+			logDir = filepath.Join("/home/", metadata.User, logDir)
+		}
 		// Refresh all configuration
 		t := task.NewBuilder().
 			UserSSH(inst.GetHost(), metadata.User).

--- a/pkg/ansible/inventory.go
+++ b/pkg/ansible/inventory.go
@@ -101,10 +101,10 @@ func parseInventory(dir string, inv *aini.InventoryData) (string, *meta.ClusterM
 		return "", nil, err
 	}
 	if port, ok := grpVarsAll["blackbox_exporter_port"]; ok {
-		clsMeta.Topology.MonitoredOptions.BlackboxExporterPort, _ = strconv.Atoi(port)
+		topo.MonitoredOptions.BlackboxExporterPort, _ = strconv.Atoi(port)
 	}
 	if port, ok := grpVarsAll["node_exporter_port"]; ok {
-		clsMeta.Topology.MonitoredOptions.NodeExporterPort, _ = strconv.Atoi(port)
+		topo.MonitoredOptions.NodeExporterPort, _ = strconv.Atoi(port)
 	}
 
 	// set hosts

--- a/pkg/meta/drainer.go
+++ b/pkg/meta/drainer.go
@@ -71,7 +71,13 @@ func (i *DrainerInstance) InitConfig(e executor.TiOpsExecutor, user string, path
 	// transfer run script
 	ends := []*scripts.PDScript{}
 	for _, spec := range i.instance.topo.PDServers {
-		ends = append(ends, scripts.NewPDScript(spec.Name, spec.Host, spec.DeployDir, spec.DataDir))
+		ends = append(ends, scripts.NewPDScript(
+			spec.Name,
+			spec.Host,
+			spec.DeployDir,
+			spec.DataDir,
+			spec.LogDir,
+		))
 	}
 
 	cfg := scripts.NewDrainerScript(
@@ -79,6 +85,7 @@ func (i *DrainerInstance) InitConfig(e executor.TiOpsExecutor, user string, path
 		i.GetHost(),
 		paths.Deploy,
 		paths.Data,
+		paths.Log,
 	).AppendEndpoints(ends...)
 
 	fp := filepath.Join(paths.Cache, fmt.Sprintf("run_drainer_%s_%d.sh", i.GetHost(), i.GetPort()))

--- a/pkg/meta/drainer.go
+++ b/pkg/meta/drainer.go
@@ -52,19 +52,19 @@ type DrainerInstance struct {
 }
 
 // ScaleConfig deploy temporary config on scaling
-func (i *DrainerInstance) ScaleConfig(e executor.TiOpsExecutor, b *Specification, user, cacheDir, deployDir string) error {
+func (i *DrainerInstance) ScaleConfig(e executor.TiOpsExecutor, b *Specification, user string, paths DirPaths) error {
 	s := i.instance.topo
 	defer func() {
 		i.instance.topo = s
 	}()
 	i.instance.topo = b
 
-	return i.InitConfig(e, user, cacheDir, deployDir)
+	return i.InitConfig(e, user, paths)
 }
 
 // InitConfig implements Instance interface.
-func (i *DrainerInstance) InitConfig(e executor.TiOpsExecutor, user, cacheDir, deployDir string) error {
-	if err := i.instance.InitConfig(e, user, cacheDir, deployDir); err != nil {
+func (i *DrainerInstance) InitConfig(e executor.TiOpsExecutor, user string, paths DirPaths) error {
+	if err := i.instance.InitConfig(e, user, paths); err != nil {
 		return err
 	}
 
@@ -77,16 +77,16 @@ func (i *DrainerInstance) InitConfig(e executor.TiOpsExecutor, user, cacheDir, d
 	cfg := scripts.NewDrainerScript(
 		i.GetHost()+":"+strconv.Itoa(i.GetPort()),
 		i.GetHost(),
-		deployDir,
-		filepath.Join(deployDir, "data"),
+		paths.Deploy,
+		paths.Data,
 	).AppendEndpoints(ends...)
 
-	fp := filepath.Join(cacheDir, fmt.Sprintf("run_drainer_%s_%d.sh", i.GetHost(), i.GetPort()))
+	fp := filepath.Join(paths.Cache, fmt.Sprintf("run_drainer_%s_%d.sh", i.GetHost(), i.GetPort()))
 
 	if err := cfg.ConfigToFile(fp); err != nil {
 		return err
 	}
-	dst := filepath.Join(deployDir, "scripts", "run_drainer.sh")
+	dst := filepath.Join(paths.Deploy, "scripts", "run_drainer.sh")
 	if err := e.Transfer(fp, dst, false); err != nil {
 		return err
 	}
@@ -96,11 +96,11 @@ func (i *DrainerInstance) InitConfig(e executor.TiOpsExecutor, user, cacheDir, d
 	}
 
 	// transfer config
-	fp = filepath.Join(cacheDir, fmt.Sprintf("drainer_%s.toml", i.GetHost()))
+	fp = filepath.Join(paths.Cache, fmt.Sprintf("drainer_%s.toml", i.GetHost()))
 	if err := config.NewDrainerConfig().ConfigToFile(fp); err != nil {
 		return err
 	}
-	dst = filepath.Join(deployDir, "conf", "drainer.toml")
+	dst = filepath.Join(paths.Deploy, "conf", "drainer.toml")
 	if err := e.Transfer(fp, dst, false); err != nil {
 		return err
 	}

--- a/pkg/meta/logic.go
+++ b/pkg/meta/logic.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 
 	"github.com/google/uuid"
 	"github.com/pingcap-incubator/tiops/pkg/executor"
@@ -59,8 +60,8 @@ type Instance interface {
 	ID() string
 	Ready(executor.TiOpsExecutor) error
 	WaitForDown(executor.TiOpsExecutor) error
-	InitConfig(executor.TiOpsExecutor, string, string, string) error
-	ScaleConfig(executor.TiOpsExecutor, *Specification, string, string, string) error
+	InitConfig(executor.TiOpsExecutor, string, DirPaths) error
+	ScaleConfig(executor.TiOpsExecutor, *Specification, string, DirPaths) error
 	ComponentName() string
 	InstanceName() string
 	ServiceName() string
@@ -72,6 +73,7 @@ type Instance interface {
 	UsedDirs() []string
 	Status(pdList ...string) string
 	DataDir() string
+	LogDir() string
 }
 
 // PortStarted wait until a port is being listened
@@ -118,12 +120,12 @@ func (i *instance) WaitForDown(e executor.TiOpsExecutor) error {
 	return PortStopped(e, i.port)
 }
 
-func (i *instance) InitConfig(e executor.TiOpsExecutor, user, cacheDir, deployDir string) error {
+func (i *instance) InitConfig(e executor.TiOpsExecutor, user string, paths DirPaths) error {
 	comp := i.ComponentName()
 	port := i.GetPort()
-	sysCfg := filepath.Join(cacheDir, fmt.Sprintf("%s-%d.service", comp, port))
+	sysCfg := filepath.Join(paths.Cache, fmt.Sprintf("%s-%d.service", comp, port))
 
-	systemCfg := system.NewConfig(comp, user, deployDir)
+	systemCfg := system.NewConfig(comp, user, paths.Deploy)
 	// For not auto start if using binlogctl to offline.
 	// bad design
 	if comp == ComponentPump || comp == ComponentDrainer {
@@ -146,8 +148,8 @@ func (i *instance) InitConfig(e executor.TiOpsExecutor, user, cacheDir, deployDi
 }
 
 // mergeServerConfig merges the server configuration and overwrite the global configuration
-func (i *instance) mergeServerConfig(e executor.TiOpsExecutor, globalConf, instanceConf yaml.MapSlice, cacheDir, deployDir string) error {
-	fp := filepath.Join(cacheDir, fmt.Sprintf("%s_%s-%d.toml", i.ComponentName(), i.GetHost(), i.GetPort()))
+func (i *instance) mergeServerConfig(e executor.TiOpsExecutor, globalConf, instanceConf yaml.MapSlice, paths DirPaths) error {
+	fp := filepath.Join(paths.Cache, fmt.Sprintf("%s_%s-%d.toml", i.ComponentName(), i.GetHost(), i.GetPort()))
 	conf, err := merge2Toml(globalConf, instanceConf)
 	if err != nil {
 		return err
@@ -156,14 +158,14 @@ func (i *instance) mergeServerConfig(e executor.TiOpsExecutor, globalConf, insta
 	if err != nil {
 		return err
 	}
-	dst := filepath.Join(deployDir, "conf", fmt.Sprintf("%s.toml", i.ComponentName()))
+	dst := filepath.Join(paths.Deploy, "conf", fmt.Sprintf("%s.toml", i.ComponentName()))
 	// transfer config
 	return e.Transfer(fp, dst, false)
 }
 
 // ScaleConfig deploy temporary config on scaling
-func (i *instance) ScaleConfig(e executor.TiOpsExecutor, b *Specification, user, cacheDir, deployDir string) error {
-	return i.InitConfig(e, user, cacheDir, deployDir)
+func (i *instance) ScaleConfig(e executor.TiOpsExecutor, b *Specification, user string, paths DirPaths) error {
+	return i.InitConfig(e, user, paths)
 }
 
 // ID returns the identifier of this instance, the ID is constructed by host:port
@@ -208,6 +210,17 @@ func (i *instance) DeployDir() string {
 
 func (i *instance) DataDir() string {
 	return reflect.ValueOf(i.InstanceSpec).FieldByName("DataDir").Interface().(string)
+}
+
+func (i *instance) LogDir() string {
+	logDir := reflect.ValueOf(i.InstanceSpec).FieldByName("DataDir").Interface().(string)
+	if logDir == "" {
+		logDir = "log"
+	}
+	if !strings.HasPrefix(logDir, "/") {
+		logDir = filepath.Join(i.DeployDir(), logDir)
+	}
+	return logDir
 }
 
 func (i *instance) GetPort() int {
@@ -268,20 +281,20 @@ type TiDBInstance struct {
 }
 
 // InitConfig implement Instance interface
-func (i *TiDBInstance) InitConfig(e executor.TiOpsExecutor, user, cacheDir, deployDir string) error {
-	if err := i.instance.InitConfig(e, user, cacheDir, deployDir); err != nil {
+func (i *TiDBInstance) InitConfig(e executor.TiOpsExecutor, user string, paths DirPaths) error {
+	if err := i.instance.InitConfig(e, user, paths); err != nil {
 		return err
 	}
 	var ends []*scripts.PDScript
 	for _, spec := range i.instance.topo.PDServers {
 		ends = append(ends, scripts.NewPDScript(spec.Name, spec.Host, spec.DeployDir, spec.DataDir))
 	}
-	cfg := scripts.NewTiDBScript(i.GetHost(), deployDir).AppendEndpoints(ends...)
-	fp := filepath.Join(cacheDir, fmt.Sprintf("run_tidb_%s.sh", i.GetHost()))
+	cfg := scripts.NewTiDBScript(i.GetHost(), paths.Deploy).AppendEndpoints(ends...)
+	fp := filepath.Join(paths.Cache, fmt.Sprintf("run_tidb_%s.sh", i.GetHost()))
 	if err := cfg.ConfigToFile(fp); err != nil {
 		return err
 	}
-	dst := filepath.Join(deployDir, "scripts", "run_tidb.sh")
+	dst := filepath.Join(paths.Deploy, "scripts", "run_tidb.sh")
 	if err := e.Transfer(fp, dst, false); err != nil {
 		return err
 	}
@@ -289,15 +302,15 @@ func (i *TiDBInstance) InitConfig(e executor.TiOpsExecutor, user, cacheDir, depl
 		return err
 	}
 	spec := i.InstanceSpec.(TiDBSpec)
-	return i.mergeServerConfig(e, i.topo.ServerConfigs.TiDB, spec.Config, cacheDir, deployDir)
+	return i.mergeServerConfig(e, i.topo.ServerConfigs.TiDB, spec.Config, paths)
 }
 
 // ScaleConfig deploy temporary config on scaling
-func (i *TiDBInstance) ScaleConfig(e executor.TiOpsExecutor, b *Specification, user, cacheDir, deployDir string) error {
+func (i *TiDBInstance) ScaleConfig(e executor.TiOpsExecutor, b *Specification, user string, paths DirPaths) error {
 	s := i.instance.topo
 	defer func() { i.instance.topo = s }()
 	i.instance.topo = b
-	return i.InitConfig(e, user, cacheDir, deployDir)
+	return i.InitConfig(e, user, paths)
 }
 
 // TiKVComponent represents TiKV component.
@@ -342,8 +355,8 @@ type TiKVInstance struct {
 }
 
 // InitConfig implement Instance interface
-func (i *TiKVInstance) InitConfig(e executor.TiOpsExecutor, user, cacheDir, deployDir string) error {
-	if err := i.instance.InitConfig(e, user, cacheDir, deployDir); err != nil {
+func (i *TiKVInstance) InitConfig(e executor.TiOpsExecutor, user string, paths DirPaths) error {
+	if err := i.instance.InitConfig(e, user, paths); err != nil {
 		return err
 	}
 
@@ -352,12 +365,12 @@ func (i *TiKVInstance) InitConfig(e executor.TiOpsExecutor, user, cacheDir, depl
 	for _, spec := range i.instance.topo.PDServers {
 		ends = append(ends, scripts.NewPDScript(spec.Name, spec.Host, spec.DeployDir, spec.DataDir))
 	}
-	cfg := scripts.NewTiKVScript(i.GetHost(), deployDir, i.instance.DataDir()).AppendEndpoints(ends...)
-	fp := filepath.Join(cacheDir, fmt.Sprintf("run_tikv_%s_%d.sh", i.GetHost(), i.GetPort()))
+	cfg := scripts.NewTiKVScript(i.GetHost(), paths.Deploy, i.instance.DataDir()).AppendEndpoints(ends...)
+	fp := filepath.Join(paths.Cache, fmt.Sprintf("run_tikv_%s_%d.sh", i.GetHost(), i.GetPort()))
 	if err := cfg.ConfigToFile(fp); err != nil {
 		return err
 	}
-	dst := filepath.Join(deployDir, "scripts", "run_tikv.sh")
+	dst := filepath.Join(paths.Deploy, "scripts", "run_tikv.sh")
 	if err := e.Transfer(fp, dst, false); err != nil {
 		return err
 	}
@@ -367,17 +380,17 @@ func (i *TiKVInstance) InitConfig(e executor.TiOpsExecutor, user, cacheDir, depl
 	}
 
 	spec := i.InstanceSpec.(TiKVSpec)
-	return i.mergeServerConfig(e, i.topo.ServerConfigs.TiKV, spec.Config, cacheDir, deployDir)
+	return i.mergeServerConfig(e, i.topo.ServerConfigs.TiKV, spec.Config, paths)
 }
 
 // ScaleConfig deploy temporary config on scaling
-func (i *TiKVInstance) ScaleConfig(e executor.TiOpsExecutor, b *Specification, user, cacheDir, deployDir string) error {
+func (i *TiKVInstance) ScaleConfig(e executor.TiOpsExecutor, b *Specification, user string, paths DirPaths) error {
 	s := i.instance.topo
 	defer func() {
 		i.instance.topo = s
 	}()
 	i.instance.topo = b
-	return i.InitConfig(e, user, cacheDir, deployDir)
+	return i.InitConfig(e, user, paths)
 }
 
 // PDComponent represents PD component.
@@ -424,8 +437,8 @@ type PDInstance struct {
 }
 
 // InitConfig implement Instance interface
-func (i *PDInstance) InitConfig(e executor.TiOpsExecutor, user, cacheDir, deployDir string) error {
-	if err := i.instance.InitConfig(e, user, cacheDir, deployDir); err != nil {
+func (i *PDInstance) InitConfig(e executor.TiOpsExecutor, user string, paths DirPaths) error {
+	if err := i.instance.InitConfig(e, user, paths); err != nil {
 		return err
 	}
 
@@ -437,12 +450,12 @@ func (i *PDInstance) InitConfig(e executor.TiOpsExecutor, user, cacheDir, deploy
 		}
 		ends = append(ends, scripts.NewPDScript(spec.Name, spec.Host, spec.DeployDir, spec.DataDir))
 	}
-	cfg := scripts.NewPDScript(name, i.GetHost(), deployDir, i.instance.DataDir()).AppendEndpoints(ends...)
-	fp := filepath.Join(cacheDir, fmt.Sprintf("run_pd_%s.sh", i.GetHost()))
+	cfg := scripts.NewPDScript(name, i.GetHost(), paths.Deploy, i.instance.DataDir()).AppendEndpoints(ends...)
+	fp := filepath.Join(paths.Cache, fmt.Sprintf("run_pd_%s.sh", i.GetHost()))
 	if err := cfg.ConfigToFile(fp); err != nil {
 		return err
 	}
-	dst := filepath.Join(deployDir, "scripts", "run_pd.sh")
+	dst := filepath.Join(paths.Deploy, "scripts", "run_pd.sh")
 	if err := e.Transfer(fp, dst, false); err != nil {
 		return err
 	}
@@ -450,12 +463,12 @@ func (i *PDInstance) InitConfig(e executor.TiOpsExecutor, user, cacheDir, deploy
 		return err
 	}
 	spec := i.InstanceSpec.(PDSpec)
-	return i.mergeServerConfig(e, i.topo.ServerConfigs.PD, spec.Config, cacheDir, deployDir)
+	return i.mergeServerConfig(e, i.topo.ServerConfigs.PD, spec.Config, paths)
 }
 
 // ScaleConfig deploy temporary config on scaling
-func (i *PDInstance) ScaleConfig(e executor.TiOpsExecutor, b *Specification, user, cacheDir, deployDir string) error {
-	if err := i.instance.ScaleConfig(e, b, user, cacheDir, deployDir); err != nil {
+func (i *PDInstance) ScaleConfig(e executor.TiOpsExecutor, b *Specification, user string, paths DirPaths) error {
+	if err := i.instance.ScaleConfig(e, b, user, paths); err != nil {
 		return err
 	}
 	ends := []*scripts.PDScript{}
@@ -467,13 +480,13 @@ func (i *PDInstance) ScaleConfig(e executor.TiOpsExecutor, b *Specification, use
 		ends = append(ends, scripts.NewPDScript(spec.Name, spec.Host, spec.DeployDir, spec.DataDir))
 	}
 
-	cfg := scripts.NewPDScaleScript(name, i.GetHost(), deployDir, i.instance.DataDir()).AppendEndpoints(ends...)
-	fp := filepath.Join(cacheDir, fmt.Sprintf("run_pd_%s_%d.sh", i.GetHost(), i.GetPort()))
+	cfg := scripts.NewPDScaleScript(name, i.GetHost(), paths.Deploy, i.instance.DataDir()).AppendEndpoints(ends...)
+	fp := filepath.Join(paths.Cache, fmt.Sprintf("run_pd_%s_%d.sh", i.GetHost(), i.GetPort()))
 	log.Infof("script path: %s", fp)
 	if err := cfg.ConfigToFile(fp); err != nil {
 		return err
 	}
-	dst := filepath.Join(deployDir, "scripts", "run_pd.sh")
+	dst := filepath.Join(paths.Deploy, "scripts", "run_pd.sh")
 	if err := e.Transfer(fp, dst, false); err != nil {
 		return err
 	}
@@ -525,18 +538,18 @@ type MonitorInstance struct {
 }
 
 // InitConfig implement Instance interface
-func (i *MonitorInstance) InitConfig(e executor.TiOpsExecutor, user, cacheDir, deployDir string) error {
-	if err := i.instance.InitConfig(e, user, cacheDir, deployDir); err != nil {
+func (i *MonitorInstance) InitConfig(e executor.TiOpsExecutor, user string, paths DirPaths) error {
+	if err := i.instance.InitConfig(e, user, paths); err != nil {
 		return err
 	}
 
 	// transfer run script
-	cfg := scripts.NewPrometheusScript(i.GetHost(), deployDir, filepath.Join(deployDir, "data")).WithPort(uint64(i.GetPort()))
-	fp := filepath.Join(cacheDir, fmt.Sprintf("run_prometheus_%s_%d.sh", i.GetHost(), i.GetPort()))
+	cfg := scripts.NewPrometheusScript(i.GetHost(), paths.Deploy, filepath.Join(paths.Deploy, "data")).WithPort(uint64(i.GetPort()))
+	fp := filepath.Join(paths.Cache, fmt.Sprintf("run_prometheus_%s_%d.sh", i.GetHost(), i.GetPort()))
 	if err := cfg.ConfigToFile(fp); err != nil {
 		return err
 	}
-	dst := filepath.Join(deployDir, "scripts", "run_prometheus.sh")
+	dst := filepath.Join(paths.Deploy, "scripts", "run_prometheus.sh")
 	if err := e.Transfer(fp, dst, false); err != nil {
 		return err
 	}
@@ -546,7 +559,7 @@ func (i *MonitorInstance) InitConfig(e executor.TiOpsExecutor, user, cacheDir, d
 	}
 
 	// transfer config
-	fp = filepath.Join(cacheDir, fmt.Sprintf("tikv_%s.yml", i.GetHost()))
+	fp = filepath.Join(paths.Cache, fmt.Sprintf("tikv_%s.yml", i.GetHost()))
 	// TODO: use real cluster name
 	cfig := config.NewPrometheusConfig("TiDB-Cluster")
 	uniqueHosts := set.NewStringSet()
@@ -583,7 +596,7 @@ func (i *MonitorInstance) InitConfig(e executor.TiOpsExecutor, user, cacheDir, d
 	if err := cfig.ConfigToFile(fp); err != nil {
 		return err
 	}
-	dst = filepath.Join(deployDir, "conf", "prometheus.yml")
+	dst = filepath.Join(paths.Deploy, "conf", "prometheus.yml")
 	if err := e.Transfer(fp, dst, false); err != nil {
 		return err
 	}
@@ -635,18 +648,18 @@ type GrafanaInstance struct {
 }
 
 // InitConfig implement Instance interface
-func (i *GrafanaInstance) InitConfig(e executor.TiOpsExecutor, user, cacheDir, deployDir string) error {
-	if err := i.instance.InitConfig(e, user, cacheDir, deployDir); err != nil {
+func (i *GrafanaInstance) InitConfig(e executor.TiOpsExecutor, user string, paths DirPaths) error {
+	if err := i.instance.InitConfig(e, user, paths); err != nil {
 		return err
 	}
 
 	// transfer run script
-	cfg := scripts.NewGrafanaScript(deployDir)
-	fp := filepath.Join(cacheDir, fmt.Sprintf("run_grafana_%s_%d.sh", i.GetHost(), i.GetPort()))
+	cfg := scripts.NewGrafanaScript(paths.Deploy)
+	fp := filepath.Join(paths.Cache, fmt.Sprintf("run_grafana_%s_%d.sh", i.GetHost(), i.GetPort()))
 	if err := cfg.ConfigToFile(fp); err != nil {
 		return err
 	}
-	dst := filepath.Join(deployDir, "scripts", "run_grafana.sh")
+	dst := filepath.Join(paths.Deploy, "scripts", "run_grafana.sh")
 	if err := e.Transfer(fp, dst, false); err != nil {
 		return err
 	}
@@ -656,31 +669,31 @@ func (i *GrafanaInstance) InitConfig(e executor.TiOpsExecutor, user, cacheDir, d
 	}
 
 	// transfer config
-	fp = filepath.Join(cacheDir, fmt.Sprintf("grafana_%s.ini", i.GetHost()))
-	if err := config.NewGrafanaConfig(i.GetHost(), deployDir).ConfigToFile(fp); err != nil {
+	fp = filepath.Join(paths.Cache, fmt.Sprintf("grafana_%s.ini", i.GetHost()))
+	if err := config.NewGrafanaConfig(i.GetHost(), paths.Deploy).ConfigToFile(fp); err != nil {
 		return err
 	}
-	dst = filepath.Join(deployDir, "conf", "grafana.ini")
+	dst = filepath.Join(paths.Deploy, "conf", "grafana.ini")
 	if err := e.Transfer(fp, dst, false); err != nil {
 		return err
 	}
 
 	// transfer dashboard.yml
-	fp = filepath.Join(cacheDir, fmt.Sprintf("dashboard_%s.yml", i.GetHost()))
-	if err := config.NewDashboardConfig("test-cluster", deployDir).ConfigToFile(fp); err != nil {
+	fp = filepath.Join(paths.Cache, fmt.Sprintf("dashboard_%s.yml", i.GetHost()))
+	if err := config.NewDashboardConfig("test-cluster", paths.Deploy).ConfigToFile(fp); err != nil {
 		return err
 	}
-	dst = filepath.Join(deployDir, "conf", "dashboard.yml")
+	dst = filepath.Join(paths.Deploy, "conf", "dashboard.yml")
 	if err := e.Transfer(fp, dst, false); err != nil {
 		return err
 	}
 
 	// transfer datasource.yml
-	fp = filepath.Join(cacheDir, fmt.Sprintf("datasource_%s.yml", i.GetHost()))
+	fp = filepath.Join(paths.Cache, fmt.Sprintf("datasource_%s.yml", i.GetHost()))
 	if err := config.NewDatasourceConfig("test-cluster", i.GetHost()).ConfigToFile(fp); err != nil {
 		return err
 	}
-	dst = filepath.Join(deployDir, "conf", "datasource.yml")
+	dst = filepath.Join(paths.Deploy, "conf", "datasource.yml")
 	if err := e.Transfer(fp, dst, false); err != nil {
 		return err
 	}

--- a/pkg/meta/paths.go
+++ b/pkg/meta/paths.go
@@ -1,0 +1,37 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package meta
+
+import (
+	"fmt"
+)
+
+// DirPaths stores the paths needed for component to put files
+type DirPaths struct {
+	Deploy string
+	Data   string
+	Log    string
+	Cache  string
+}
+
+// String implements the fmt.Stringer interface
+func (p *DirPaths) String() string {
+	return fmt.Sprintf(
+		"deploy_dir=%s, data_dir=%s, log_dir=%s, cache_dir=%s",
+		p.Deploy,
+		p.Data,
+		p.Log,
+		p.Cache,
+	)
+}

--- a/pkg/meta/pump.go
+++ b/pkg/meta/pump.go
@@ -71,7 +71,13 @@ func (i *PumpInstance) InitConfig(e executor.TiOpsExecutor, user string, paths D
 	// transfer run script
 	ends := []*scripts.PDScript{}
 	for _, spec := range i.instance.topo.PDServers {
-		ends = append(ends, scripts.NewPDScript(spec.Name, spec.Host, spec.DeployDir, spec.DataDir))
+		ends = append(ends, scripts.NewPDScript(
+			spec.Name,
+			spec.Host,
+			spec.DeployDir,
+			spec.DataDir,
+			spec.LogDir,
+		))
 	}
 
 	cfg := scripts.NewPumpScript(
@@ -79,6 +85,7 @@ func (i *PumpInstance) InitConfig(e executor.TiOpsExecutor, user string, paths D
 		i.GetHost(),
 		paths.Deploy,
 		paths.Data,
+		paths.Log,
 	).AppendEndpoints(ends...)
 
 	fp := filepath.Join(paths.Cache, fmt.Sprintf("run_pump_%s_%d.sh", i.GetHost(), i.GetPort()))

--- a/pkg/meta/pump.go
+++ b/pkg/meta/pump.go
@@ -52,19 +52,19 @@ type PumpInstance struct {
 }
 
 // ScaleConfig deploy temporary config on scaling
-func (i *PumpInstance) ScaleConfig(e executor.TiOpsExecutor, b *Specification, user, cacheDir, deployDir string) error {
+func (i *PumpInstance) ScaleConfig(e executor.TiOpsExecutor, b *Specification, user string, paths DirPaths) error {
 	s := i.instance.topo
 	defer func() {
 		i.instance.topo = s
 	}()
 	i.instance.topo = b
 
-	return i.InitConfig(e, user, cacheDir, deployDir)
+	return i.InitConfig(e, user, paths)
 }
 
 // InitConfig implements Instance interface.
-func (i *PumpInstance) InitConfig(e executor.TiOpsExecutor, user, cacheDir, deployDir string) error {
-	if err := i.instance.InitConfig(e, user, cacheDir, deployDir); err != nil {
+func (i *PumpInstance) InitConfig(e executor.TiOpsExecutor, user string, paths DirPaths) error {
+	if err := i.instance.InitConfig(e, user, paths); err != nil {
 		return err
 	}
 
@@ -77,16 +77,16 @@ func (i *PumpInstance) InitConfig(e executor.TiOpsExecutor, user, cacheDir, depl
 	cfg := scripts.NewPumpScript(
 		i.GetHost()+":"+strconv.Itoa(i.GetPort()),
 		i.GetHost(),
-		deployDir,
-		filepath.Join(deployDir, "data"),
+		paths.Deploy,
+		paths.Data,
 	).AppendEndpoints(ends...)
 
-	fp := filepath.Join(cacheDir, fmt.Sprintf("run_pump_%s_%d.sh", i.GetHost(), i.GetPort()))
+	fp := filepath.Join(paths.Cache, fmt.Sprintf("run_pump_%s_%d.sh", i.GetHost(), i.GetPort()))
 
 	if err := cfg.ConfigToFile(fp); err != nil {
 		return err
 	}
-	dst := filepath.Join(deployDir, "scripts", "run_pump.sh")
+	dst := filepath.Join(paths.Deploy, "scripts", "run_pump.sh")
 	if err := e.Transfer(fp, dst, false); err != nil {
 		return err
 	}
@@ -96,11 +96,11 @@ func (i *PumpInstance) InitConfig(e executor.TiOpsExecutor, user, cacheDir, depl
 	}
 
 	// transfer config
-	fp = filepath.Join(cacheDir, fmt.Sprintf("pump_%s.toml", i.GetHost()))
+	fp = filepath.Join(paths.Cache, fmt.Sprintf("pump_%s.toml", i.GetHost()))
 	if err := config.NewPumpConfig().ConfigToFile(fp); err != nil {
 		return err
 	}
-	dst = filepath.Join(deployDir, "conf", "pump.toml")
+	dst = filepath.Join(paths.Deploy, "conf", "pump.toml")
 	if err := e.Transfer(fp, dst, false); err != nil {
 		return err
 	}

--- a/pkg/meta/topology.go
+++ b/pkg/meta/topology.go
@@ -449,10 +449,6 @@ func (topo *TopologySpecification) UnmarshalYAML(unmarshal func(interface{}) err
 		topo.MonitoredOptions.DataDir = filepath.Join(topo.GlobalOptions.DataDir,
 			fmt.Sprintf("%s-%d", RoleMonitor, topo.MonitoredOptions.NodeExporterPort))
 	}
-	if topo.MonitoredOptions.LogDir == "" {
-		topo.MonitoredOptions.LogDir = filepath.Join(topo.GlobalOptions.LogDir,
-			fmt.Sprintf("%s-%d", RoleMonitor, topo.MonitoredOptions.NodeExporterPort))
-	}
 
 	if err := fillCustomDefaults(&topo.GlobalOptions, topo); err != nil {
 		return err
@@ -721,8 +717,6 @@ func setCustomDefaults(globalOptions *GlobalOptions, field reflect.Value) error 
 			setDefaultDir(globalOptions.DataDir, field.Interface().(InstanceSpec).Role(), getPort(field), field.Field(j))
 		case "DeployDir":
 			setDefaultDir(globalOptions.DeployDir, field.Interface().(InstanceSpec).Role(), getPort(field), field.Field(j))
-		case "LogDir":
-			setDefaultDir(globalOptions.LogDir, field.Interface().(InstanceSpec).Role(), getPort(field), field.Field(j))
 		}
 	}
 

--- a/pkg/operation/destroy.go
+++ b/pkg/operation/destroy.go
@@ -2,6 +2,7 @@ package operator
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/pingcap-incubator/tiops/pkg/log"
 	"github.com/pingcap-incubator/tiops/pkg/meta"
@@ -39,12 +40,13 @@ func DestroyComponent(getter ExecutorGetter, instances []meta.Instance) error {
 		log.Infof("Destroying instance %s", ins.GetHost())
 
 		// Stop by systemd.
-		var command string
+		delPaths := make([]string, 0)
 		switch name {
 		case meta.ComponentTiKV, meta.ComponentPD, meta.ComponentPump, meta.ComponentDrainer, meta.ComponentPrometheus, meta.ComponentAlertManager:
-			command = command + fmt.Sprintf("rm -rf %s;", ins.DataDir())
+			delPaths = append(delPaths, ins.DataDir())
+			fallthrough
 		default:
-			command = ""
+			delPaths = append(delPaths, ins.LogDir())
 		}
 
 		// In TiDB-Ansible, deploy dir are shared by all components on the same
@@ -52,14 +54,14 @@ func DestroyComponent(getter ExecutorGetter, instances []meta.Instance) error {
 		// TODO: this may leave undeleted files when destroying the cluster, fix
 		// that later.
 		if !ins.IsImported() {
-			command += fmt.Sprintf("rm -rf %s;", ins.DeployDir())
+			delPaths = append(delPaths, ins.DeployDir())
 		} else {
 			log.Warnf("Deploy dir %s not deleted for TiDB-Ansible imported instance %s.",
 				ins.DeployDir(), ins.InstanceName())
 		}
-		command = command + fmt.Sprintf("rm -rf /etc/systemd/system/%s;", ins.ServiceName())
+		delPaths = append(delPaths, fmt.Sprintf("/etc/systemd/system/%s", ins.ServiceName()))
 		c := module.ShellModuleConfig{
-			Command:  command,
+			Command:  fmt.Sprintf("rm -rf %s;", strings.Join(delPaths, " ")),
 			Sudo:     true, // the .service files are in a directory owned by root
 			Chdir:    "",
 			UseShell: false,

--- a/pkg/operation/destroy.go
+++ b/pkg/operation/destroy.go
@@ -19,7 +19,7 @@ func Destroy(
 	for _, com := range coms {
 		err := DestroyComponent(getter, com.Instances())
 		if err != nil {
-			return errors.Annotatef(err, "failed to stop %s", com.Name())
+			return errors.Annotatef(err, "failed to destroy %s", com.Name())
 		}
 	}
 	return nil

--- a/pkg/task/builder.go
+++ b/pkg/task/builder.go
@@ -121,24 +121,24 @@ func (b *Builder) BackupComponent(component, fromVer string, dstHost, dstDir str
 }
 
 // InitConfig appends a CopyComponent task to the current task collection
-func (b *Builder) InitConfig(name string, inst meta.Instance, deployUser, deployDir string) *Builder {
+func (b *Builder) InitConfig(name string, inst meta.Instance, deployUser string, paths meta.DirPaths) *Builder {
 	b.tasks = append(b.tasks, &InitConfig{
 		name:       name,
 		instance:   inst,
 		deployUser: deployUser,
-		deployDir:  deployDir,
+		paths:      paths,
 	})
 	return b
 }
 
 // ScaleConfig generate temporary config on scaling
-func (b *Builder) ScaleConfig(name string, base *meta.TopologySpecification, inst meta.Instance, deployUser, deployDir string) *Builder {
+func (b *Builder) ScaleConfig(name string, base *meta.TopologySpecification, inst meta.Instance, deployUser string, paths meta.DirPaths) *Builder {
 	b.tasks = append(b.tasks, &ScaleConfig{
 		name:       name,
 		base:       base,
 		instance:   inst,
 		deployUser: deployUser,
-		deployDir:  deployDir,
+		paths:      paths,
 	})
 	return b
 }

--- a/pkg/task/builder.go
+++ b/pkg/task/builder.go
@@ -144,14 +144,14 @@ func (b *Builder) ScaleConfig(name string, base *meta.TopologySpecification, ins
 }
 
 // MonitoredConfig appends a CopyComponent task to the current task collection
-func (b *Builder) MonitoredConfig(name, comp, host string, options meta.MonitoredOptions, deployUser, deployDir string) *Builder {
+func (b *Builder) MonitoredConfig(name, comp, host string, options meta.MonitoredOptions, deployUser string, paths meta.DirPaths) *Builder {
 	b.tasks = append(b.tasks, &MonitoredConfig{
 		name:       name,
 		component:  comp,
 		host:       host,
 		options:    options,
 		deployUser: deployUser,
-		deployDir:  deployDir,
+		paths:      paths,
 	})
 	return b
 }

--- a/pkg/task/init_config.go
+++ b/pkg/task/init_config.go
@@ -26,7 +26,7 @@ type InitConfig struct {
 	name       string
 	instance   meta.Instance
 	deployUser string
-	deployDir  string
+	paths      meta.DirPaths
 }
 
 // Execute implements the Task interface
@@ -37,12 +37,12 @@ func (c *InitConfig) Execute(ctx *Context) error {
 		return ErrNoExecutor
 	}
 
-	cacheConfigDir := meta.ClusterPath(c.name, "config")
-	if err := os.MkdirAll(cacheConfigDir, 0755); err != nil {
+	c.paths.Cache = meta.ClusterPath(c.name, "config")
+	if err := os.MkdirAll(c.paths.Cache, 0755); err != nil {
 		return err
 	}
 
-	return c.instance.InitConfig(exec, c.deployUser, cacheConfigDir, c.deployDir)
+	return c.instance.InitConfig(exec, c.deployUser, c.paths)
 }
 
 // Rollback implements the Task interface
@@ -52,7 +52,7 @@ func (c *InitConfig) Rollback(ctx *Context) error {
 
 // String implements the fmt.Stringer interface
 func (c *InitConfig) String() string {
-	return fmt.Sprintf("InitConfig: cluster=%s, user=%s, host=%s, path=%s, targetDir=%s",
+	return fmt.Sprintf("InitConfig: cluster=%s, user=%s, host=%s, path=%s, %s",
 		c.name, c.deployUser, c.instance.GetHost(),
-		filepath.Join(meta.ClusterPath(c.name, "config", c.instance.ServiceName())), c.deployDir)
+		filepath.Join(meta.ClusterPath(c.name, "config", c.instance.ServiceName())), c.paths)
 }

--- a/pkg/task/scale_config.go
+++ b/pkg/task/scale_config.go
@@ -26,7 +26,7 @@ type ScaleConfig struct {
 	instance   meta.Instance
 	base       *meta.TopologySpecification
 	deployUser string
-	deployDir  string
+	paths      meta.DirPaths
 }
 
 // Execute implements the Task interface
@@ -37,12 +37,12 @@ func (c *ScaleConfig) Execute(ctx *Context) error {
 		return ErrNoExecutor
 	}
 
-	cacheConfigDir := meta.ClusterPath(c.name, "config")
-	if err := os.MkdirAll(cacheConfigDir, 0755); err != nil {
+	c.paths.Cache = meta.ClusterPath(c.name, "config")
+	if err := os.MkdirAll(c.paths.Cache, 0755); err != nil {
 		return err
 	}
 
-	return c.instance.ScaleConfig(exec, c.base, c.deployUser, cacheConfigDir, c.deployDir)
+	return c.instance.ScaleConfig(exec, c.base, c.deployUser, c.paths)
 }
 
 // Rollback implements the Task interface
@@ -52,6 +52,6 @@ func (c *ScaleConfig) Rollback(ctx *Context) error {
 
 // String implements the fmt.Stringer interface
 func (c *ScaleConfig) String() string {
-	return fmt.Sprintf("ScaleConfig: cluster=%s, user=%s, host=%s, service=%s, dir=%s",
-		c.name, c.deployUser, c.instance.GetHost(), c.instance.ServiceName(), c.deployDir)
+	return fmt.Sprintf("ScaleConfig: cluster=%s, user=%s, host=%s, service=%s, %s",
+		c.name, c.deployUser, c.instance.GetHost(), c.instance.ServiceName(), c.paths)
 }

--- a/pkg/template/scripts/alertmanager.go
+++ b/pkg/template/scripts/alertmanager.go
@@ -29,16 +29,18 @@ type AlertManagerScript struct {
 	ClusterPort uint64
 	DeployDir   string
 	DataDir     string
+	LogDir      string
 	NumaNode    string
 }
 
 // NewAlertManagerScript returns a AlertManagerScript with given arguments
-func NewAlertManagerScript(deployDir, dataDir string) *AlertManagerScript {
+func NewAlertManagerScript(deployDir, dataDir, logDir string) *AlertManagerScript {
 	return &AlertManagerScript{
 		WebPort:     8888,
 		ClusterPort: 9999,
 		DeployDir:   deployDir,
 		DataDir:     dataDir,
+		LogDir:      logDir,
 	}
 }
 

--- a/pkg/template/scripts/blackbox_exporter.go
+++ b/pkg/template/scripts/blackbox_exporter.go
@@ -27,14 +27,16 @@ import (
 type BlackboxExporterScript struct {
 	Port      uint64
 	DeployDir string
+	LogDir    string
 	NumaNode  string
 }
 
 // NewBlackboxExporterScript returns a BlackboxExporterScript with given arguments
-func NewBlackboxExporterScript(deployDir string) *BlackboxExporterScript {
+func NewBlackboxExporterScript(deployDir, logDir string) *BlackboxExporterScript {
 	return &BlackboxExporterScript{
 		Port:      9115,
 		DeployDir: deployDir,
+		LogDir:    logDir,
 	}
 }
 

--- a/pkg/template/scripts/drainer.go
+++ b/pkg/template/scripts/drainer.go
@@ -30,19 +30,21 @@ type DrainerScript struct {
 	Port      uint64
 	DeployDir string
 	DataDir   string
+	LogDir    string
 	NumaNode  string
 	CommitTs  int64
 	Endpoints []*PDScript
 }
 
 // NewDrainerScript returns a DrainerScript with given arguments
-func NewDrainerScript(nodeID, ip, deployDir, dataDir string) *DrainerScript {
+func NewDrainerScript(nodeID, ip, deployDir, dataDir, logDir string) *DrainerScript {
 	return &DrainerScript{
 		NodeID:    nodeID,
 		IP:        ip,
 		Port:      8249,
 		DeployDir: deployDir,
 		DataDir:   dataDir,
+		LogDir:    logDir,
 		CommitTs:  -1,
 	}
 }

--- a/pkg/template/scripts/node_exporter.go
+++ b/pkg/template/scripts/node_exporter.go
@@ -25,16 +25,18 @@ import (
 
 // NodeExporterScript represent the data to generate NodeExporter config
 type NodeExporterScript struct {
-	DeployDir string
-	NumaNode  string
 	Port      uint64
+	DeployDir string
+	LogDir    string
+	NumaNode  string
 }
 
 // NewNodeExporterScript returns a NodeExporterScript with given arguments
-func NewNodeExporterScript(deployDir string) *NodeExporterScript {
+func NewNodeExporterScript(deployDir, logDir string) *NodeExporterScript {
 	return &NodeExporterScript{
-		DeployDir: deployDir,
 		Port:      9100,
+		DeployDir: deployDir,
+		LogDir:    logDir,
 	}
 }
 

--- a/pkg/template/scripts/pd.go
+++ b/pkg/template/scripts/pd.go
@@ -34,12 +34,13 @@ type PDScript struct {
 	PeerPort   uint64
 	DeployDir  string
 	DataDir    string
+	LogDir     string
 	NumaNode   string
 	Endpoints  []*PDScript
 }
 
 // NewPDScript returns a PDScript with given arguments
-func NewPDScript(name, ip, deployDir, dataDir string) *PDScript {
+func NewPDScript(name, ip, deployDir, dataDir, logDir string) *PDScript {
 	return &PDScript{
 		Name:       name,
 		Scheme:     "http",
@@ -48,6 +49,7 @@ func NewPDScript(name, ip, deployDir, dataDir string) *PDScript {
 		PeerPort:   2380,
 		DeployDir:  deployDir,
 		DataDir:    dataDir,
+		LogDir:     logDir,
 	}
 }
 
@@ -131,8 +133,8 @@ type PDScaleScript struct {
 }
 
 // NewPDScaleScript return a new PDScaleScript
-func NewPDScaleScript(name, ip, deployDir, dataDir string) *PDScaleScript {
-	return &PDScaleScript{*NewPDScript(name, ip, deployDir, dataDir)}
+func NewPDScaleScript(name, ip, deployDir, dataDir, logDir string) *PDScaleScript {
+	return &PDScaleScript{*NewPDScript(name, ip, deployDir, dataDir, logDir)}
 }
 
 // WithScheme set Scheme field of PDScaleScript

--- a/pkg/template/scripts/prometheus.go
+++ b/pkg/template/scripts/prometheus.go
@@ -29,16 +29,18 @@ type PrometheusScript struct {
 	Port      uint64
 	DeployDir string
 	DataDir   string
+	LogDir    string
 	NumaNode  string
 }
 
 // NewPrometheusScript returns a PrometheusScript with given arguments
-func NewPrometheusScript(ip, deployDir, dataDir string) *PrometheusScript {
+func NewPrometheusScript(ip, deployDir, dataDir, logDir string) *PrometheusScript {
 	return &PrometheusScript{
 		IP:        ip,
 		Port:      9090,
 		DeployDir: deployDir,
 		DataDir:   dataDir,
+		LogDir:    logDir,
 	}
 }
 

--- a/pkg/template/scripts/pump.go
+++ b/pkg/template/scripts/pump.go
@@ -30,19 +30,21 @@ type PumpScript struct {
 	Port      uint64
 	DeployDir string
 	DataDir   string
+	LogDir    string
 	NumaNode  string
 	CommitTs  int64
 	Endpoints []*PDScript
 }
 
 // NewPumpScript returns a PumpScript with given arguments
-func NewPumpScript(nodeID, host, deployDir, dataDir string) *PumpScript {
+func NewPumpScript(nodeID, host, deployDir, dataDir, logDir string) *PumpScript {
 	return &PumpScript{
 		NodeID:    nodeID,
 		Host:      host,
 		Port:      8250,
 		DeployDir: deployDir,
 		DataDir:   dataDir,
+		LogDir:    logDir,
 	}
 }
 

--- a/pkg/template/scripts/tidb.go
+++ b/pkg/template/scripts/tidb.go
@@ -29,17 +29,19 @@ type TiDBScript struct {
 	Port       uint64
 	StatusPort uint64
 	DeployDir  string
+	LogDir     string
 	NumaNode   string
 	Endpoints  []*PDScript
 }
 
 // NewTiDBScript returns a TiDBScript with given arguments
-func NewTiDBScript(ip, deployDir string) *TiDBScript {
+func NewTiDBScript(ip, deployDir, logDir string) *TiDBScript {
 	return &TiDBScript{
 		IP:         ip,
 		Port:       4000,
 		StatusPort: 10080,
 		DeployDir:  deployDir,
+		LogDir:     logDir,
 	}
 }
 

--- a/pkg/template/scripts/tikv.go
+++ b/pkg/template/scripts/tikv.go
@@ -30,18 +30,20 @@ type TiKVScript struct {
 	StatusPort uint64
 	DeployDir  string
 	DataDir    string
+	LogDir     string
 	NumaNode   string
 	Endpoints  []*PDScript
 }
 
 // NewTiKVScript returns a TiKVScript with given arguments
-func NewTiKVScript(ip, deployDir, dataDir string) *TiKVScript {
+func NewTiKVScript(ip, deployDir, dataDir, logDir string) *TiKVScript {
 	return &TiKVScript{
 		IP:         ip,
 		Port:       20160,
 		StatusPort: 20180,
 		DeployDir:  deployDir,
 		DataDir:    dataDir,
+		LogDir:     logDir,
 	}
 }
 

--- a/pkg/utils/tui.go
+++ b/pkg/utils/tui.go
@@ -18,8 +18,10 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"syscall"
 
 	"github.com/AstroProfundis/tabby"
+	"golang.org/x/crypto/ssh/terminal"
 )
 
 // PrintTable accepts a matrix of strings and print them as ASCII table to terminal
@@ -64,4 +66,18 @@ func Prompt(prompt string) string {
 		return ""
 	}
 	return strings.TrimSuffix(input, "\n")
+}
+
+// GetPasswd reads a password input from console
+func GetPasswd(prompt string) string {
+	if prompt != "" {
+		prompt += " " // append a whitespace
+	}
+	fmt.Printf(prompt)
+
+	input, err := terminal.ReadPassword(int(syscall.Stdin))
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(strings.Trim(string(input), "\n"))
 }

--- a/templates/scripts/run_alertmanager.sh.tpl
+++ b/templates/scripts/run_alertmanager.sh.tpl
@@ -7,6 +7,9 @@ cd "${DEPLOY_DIR}" || exit 1
 # WARNING: This file was auto-generated. Do not edit!
 #          All your edit might be overwritten!
 
+exec > >(tee -i -a "{{.LogDir}}/alertmanager.log")
+exec 2>&1
+
 {{- if .NumaNode}}
 exec numactl --cpunodebind={{.NumaNode}} --membind={{.NumaNode}} bin/alertmanager \
 {{- else}}

--- a/templates/scripts/run_blackbox_exporter.sh.tpl
+++ b/templates/scripts/run_blackbox_exporter.sh.tpl
@@ -6,6 +6,9 @@ set -e
 DEPLOY_DIR={{.DeployDir}}
 cd "${DEPLOY_DIR}" || exit 1
 
+exec > >(tee -i -a "{{.LogDir}}/blackbox_exporter.log")
+exec 2>&1
+
 {{- if .NumaNode}}
 exec numactl --cpunodebind={{.NumaNode}} --membind={{.NumaNode}} bin/blackbox_exporter/blackbox_exporter \
 {{- else}}

--- a/templates/scripts/run_drainer.sh.tpl
+++ b/templates/scripts/run_drainer.sh.tpl
@@ -26,6 +26,6 @@ exec bin/drainer \
     --addr="{{.IP}}:{{.Port}}" \
     --pd-urls="{{template "PDList" .Endpoints}}" \
     --data-dir="{{.DataDir}}" \
-    --log-file="log/drainer.log" \
+    --log-file="{{.LogDir}}/drainer.log" \
     --config=conf/drainer.toml \
-    --initial-commit-ts="{{.CommitTs}}" 2>> "log/drainer_stderr.log"
+    --initial-commit-ts="{{.CommitTs}}" 2>> "{{.LogDir}}/drainer_stderr.log"

--- a/templates/scripts/run_node_exporter.sh.tpl
+++ b/templates/scripts/run_node_exporter.sh.tpl
@@ -6,6 +6,9 @@ set -e
 DEPLOY_DIR={{.DeployDir}}
 cd "${DEPLOY_DIR}" || exit 1
 
+exec > >(tee -i -a "{{.LogDir}}/node_exporter.log")
+exec 2>&1
+
 {{- if .NumaNode}}
 exec numactl --cpunodebind={{.NumaNode}} --membind={{.NumaNode}} bin/node_exporter/node_exporter \
 {{- else}}

--- a/templates/scripts/run_pd.sh.tpl
+++ b/templates/scripts/run_pd.sh.tpl
@@ -29,5 +29,5 @@ exec bin/pd-server \
     --advertise-peer-urls="{{.Scheme}}://{{.IP}}:{{.PeerPort}}" \
     --data-dir="{{.DataDir}}" \
     --initial-cluster="{{template "PDList" .Endpoints}}" \
-    --log-file="log/pd.log" 2>> "log/pd_stderr.log"
+    --log-file="{{.LogDir}}/pd.log" 2>> "{{.LogDir}}/pd_stderr.log"
   

--- a/templates/scripts/run_pd_scale.sh.tpl
+++ b/templates/scripts/run_pd_scale.sh.tpl
@@ -29,5 +29,5 @@ exec bin/pd-server \
     --advertise-peer-urls="{{.Scheme}}://{{.IP}}:{{.PeerPort}}" \
     --data-dir="{{.DataDir}}" \
     --join="{{template "PDList" .Endpoints}}" \
-    --log-file="log/pd.log" 2>> "log/pd_stderr.log"
+    --log-file="{{.LogDir}}/pd.log" 2>> "{{.LogDir}}/pd_stderr.log"
   

--- a/templates/scripts/run_prometheus.sh.tpl
+++ b/templates/scripts/run_prometheus.sh.tpl
@@ -9,6 +9,9 @@ cd "${DEPLOY_DIR}" || exit 1
 
 cp {{.DeployDir}}/bin/prometheus/*.rules.yml {{.DeployDir}}/conf/
 
+exec > >(tee -i -a "{{.LogDir}}/prometheus.log")
+exec 2>&1
+
 {{- if .NumaNode}}
 exec numactl --cpunodebind={{.NumaNode}} --membind={{.NumaNode}} bin/prometheus/prometheus \
 {{- else}}

--- a/templates/scripts/run_pump.sh.tpl
+++ b/templates/scripts/run_pump.sh.tpl
@@ -27,5 +27,5 @@ exec bin/pump \
     --advertise-addr="{{.Host}}:{{.Port}}" \
     --pd-urls="{{template "PDList" .Endpoints}}" \
     --data-dir="{{.DataDir}}" \
-    --log-file="log/pump.log" \
-    --config=conf/pump.toml 2>> "log/pump_stderr.log"
+    --log-file="{{.LogDir}}/pump.log" \
+    --config=conf/pump.toml 2>> "{{.LogDir}}/pump_stderr.log"

--- a/templates/scripts/run_tidb.sh.tpl
+++ b/templates/scripts/run_tidb.sh.tpl
@@ -28,4 +28,4 @@ exec bin/tidb-server \
     --store="tikv" \
     --path="{{template "PDList" .Endpoints}}" \
     --log-slow-query="log/tidb_slow_query.log" \
-    --log-file="log/tidb.log" 2>> "log/tidb_stderr.log"
+    --log-file="{{.LogDir}}/tidb.log" 2>> "{{.LogDir}}/tidb_stderr.log"

--- a/templates/scripts/run_tikv.sh.tpl
+++ b/templates/scripts/run_tikv.sh.tpl
@@ -31,4 +31,4 @@ exec bin/tikv-server \
     --pd "{{template "PDList" .Endpoints}}" \
     --data-dir "{{.DataDir}}" \
     --config conf/tikv.toml \
-    --log-file "log/tikv.log" 2>> "log/tikv_stderr.log"
+    --log-file "{{.LogDir}}/tikv.log" 2>> "{{.LogDir}}/tikv_stderr.log"


### PR DESCRIPTION
1. In TiDB-Ansible deployed clusters, multiple instances on the same host shares `deploy_dir`, so not deleting the `deploy_dir` on `scale-in`.

  > We need some methods to delete them for `destroy`.

2. Also added a prompt for `destroy`.

3. Properly set `LogDir` for components