### PR TITLE
Fix permission and executor error

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -200,6 +200,7 @@ func buildMonitoredDeployTask(
 
 			// Deploy component
 			t := task.NewBuilder().
+				UserSSH(host, globalOptions.User).
 				Mkdir(host,
 					filepath.Join(deployDir, "bin"),
 					filepath.Join(deployDir, "conf"),

--- a/cmd/scale_out.go
+++ b/cmd/scale_out.go
@@ -168,7 +168,9 @@ func buildScaleOutTask(
 		Parallel(downloadCompTasks...).
 		Parallel(deployCompTasks...).
 		// TODO: find another way to make sure current cluster started
+		ClusterSSH(metadata.Topology, metadata.User).
 		ClusterOperate(metadata.Topology, operator.StartOperation, operator.Options{}).
+		ClusterSSH(newPart, metadata.User).
 		ClusterOperate(newPart, operator.StartOperation, operator.Options{}).
 		Parallel(refreshConfigTasks...).
 		Build(), nil


### PR DESCRIPTION
This PR fixes two errors:

- Permission denied caused by mkdir by root

- Cannot find executor for xxx.xxx.xx.xxx during the start process of scaling out.