### PR TITLE
Support edit config

### DIFF
--- a/cmd/edit_config.go
+++ b/cmd/edit_config.go
@@ -1,0 +1,136 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"strings"
+
+	"github.com/fatih/color"
+	"github.com/pingcap-incubator/tiops/pkg/edit"
+	"github.com/pingcap-incubator/tiops/pkg/log"
+	"github.com/pingcap-incubator/tiops/pkg/meta"
+	"github.com/pingcap-incubator/tiops/pkg/utils"
+	tiuputils "github.com/pingcap-incubator/tiup/pkg/utils"
+	"github.com/pingcap/errors"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v2"
+)
+
+func newEditConfigCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "edit-config <cluster-name>",
+		Short: "Edit TiDB cluster config",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 1 {
+				return cmd.Help()
+			}
+
+			clusterName := args[0]
+			if tiuputils.IsNotExist(meta.ClusterPath(clusterName, meta.MetaFileName)) {
+				return errors.Errorf("cannot start non-exists cluster %s", clusterName)
+			}
+
+			auditConfig.enable = true
+			metadata, err := meta.ClusterMetadata(clusterName)
+			if err != nil {
+				return err
+			}
+
+			return editTopo(clusterName, metadata)
+		},
+	}
+
+	return cmd
+}
+
+// 1. Write Topology to a temporary file.
+// 2. Open file in editro.
+// 3. Check and update Topology.
+// 4. Save meta file.
+func editTopo(clusterName string, metadata *meta.ClusterMeta) error {
+	data, err := yaml.Marshal(metadata.Topology)
+	if err != nil {
+		return errors.AddStack(err)
+	}
+
+	file, err := ioutil.TempFile(os.TempDir(), "*")
+	if err != nil {
+		return errors.AddStack(err)
+	}
+
+	name := file.Name()
+
+	_, err = io.Copy(file, bytes.NewReader(data))
+	if err != nil {
+		return errors.AddStack(err)
+	}
+
+	err = file.Close()
+	if err != nil {
+		return errors.AddStack(err)
+	}
+
+	err = edit.OpenFileInEditor(name)
+	if err != nil {
+		return errors.AddStack(err)
+	}
+
+	// Now user finish editing the file.
+	newData, err := ioutil.ReadFile(name)
+	if err != nil {
+		return errors.AddStack(err)
+	}
+
+	newTopo := new(meta.TopologySpecification)
+	err = yaml.Unmarshal(newData, newTopo)
+	if err != nil {
+		log.Infof("The file is not in the correct format")
+		return errors.AddStack(err)
+	}
+
+	if bytes.Equal(data, newData) {
+		log.Infof("The file has nothing changed")
+		return nil
+	}
+
+	edit.ShowDiff(string(data), string(newData), os.Stdout)
+
+	msg := fmt.Sprintf(color.HiYellowString("Please check change, do you want to apply the change?"))
+	msg = msg + "\n[Y]es/[N]o:"
+	ans := utils.Prompt(msg)
+	switch strings.ToLower(ans) {
+	case "y", "yes":
+		log.Infof("Apply the change...")
+
+		metadata.Topology = newTopo
+		err = meta.SaveClusterMeta(clusterName, metadata)
+		if err != nil {
+			return errors.Annotate(err, "failed to save")
+		}
+
+		log.Infof("Apply change success.")
+
+		return nil
+	case "n", "no":
+		fallthrough
+	default:
+		log.Infof("Abandom the change")
+		return nil
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -89,6 +89,7 @@ func init() {
 		newListCmd(),
 		newAuditCmd(),
 		newImportCmd(),
+		newEditConfigCmd(),
 	)
 }
 

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/pingcap/kvproto v0.0.0-20200317095539-c42a1d8db7d3
 	github.com/pingcap/pd/v4 v4.0.0-beta.2
 	github.com/relex/aini v1.1.3
+	github.com/sergi/go-diff v1.0.1-0.20180205163309-da645544ed44
 	github.com/spf13/cobra v0.0.6
 	go.etcd.io/etcd v0.5.0-alpha.5.0.20191023171146-3cf2f69b5738
 	golang.org/x/crypto v0.0.0-20200109152110-61a87790db17

--- a/go.sum
+++ b/go.sum
@@ -317,7 +317,6 @@ github.com/onsi/gomega v1.5.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1Cpa
 github.com/opentracing/opentracing-go v1.0.2 h1:3jA2P6O1F9UOrWVpwrIo17pu01KWvNWg4X946/Y5Zwg=
 github.com/opentracing/opentracing-go v1.0.2/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
-github.com/pelletier/go-toml v1.3.0 h1:e5+lF2E4Y2WCIxBefVowBuB0iHrUH4HZ8q+6mGF7fJc=
 github.com/pelletier/go-toml v1.3.0/go.mod h1:PN7xzY2wHTK0K9p34ErDQMlFxa51Fk0OUruD3k1mMwo=
 github.com/phf/go-queue v0.0.0-20170504031614-9abe38d0371d h1:U+PMnTlV2tu7RuMK5etusZG3Cf+rpow5hqQByeCzJ2g=
 github.com/phf/go-queue v0.0.0-20170504031614-9abe38d0371d/go.mod h1:lXfE4PvvTW5xOjO6Mba8zDPyw8M93B6AQ7frTGnMlA8=
@@ -387,6 +386,7 @@ github.com/rs/cors v1.7.0/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
+github.com/sergi/go-diff v1.0.1-0.20180205163309-da645544ed44 h1:tB9NOR21++IjLyVx3/PCPhWMwqGNCMQEH96A6dMZ/gc=
 github.com/sergi/go-diff v1.0.1-0.20180205163309-da645544ed44/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/shirou/gopsutil v2.19.10+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
 github.com/shirou/gopsutil v2.20.2+incompatible h1:ucK79BhBpgqQxPASyS2cu9HX8cfDVljBN1WWFvbNvgY=

--- a/pkg/edit/diff.go
+++ b/pkg/edit/diff.go
@@ -1,0 +1,17 @@
+package edit
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/sergi/go-diff/diffmatchpatch"
+)
+
+// ShowDiff write diff result into the Writer.
+// return false if there's no diff.
+func ShowDiff(t1 string, t2 string, w io.Writer) {
+	dmp := diffmatchpatch.New()
+	diffs := dmp.DiffMain(t1, t2, false)
+
+	fmt.Fprint(w, dmp.DiffPrettyText(diffs))
+}

--- a/pkg/edit/edit.go
+++ b/pkg/edit/edit.go
@@ -1,0 +1,63 @@
+package edit
+
+import (
+	"io/ioutil"
+	"os"
+	"os/exec"
+)
+
+// ref: https://samrapdev.com/capturing-sensitive-input-with-editor-in-golang-from-the-cli/
+
+// DefaultEditor is vim because we're adults ;)
+const DefaultEditor = "vim"
+
+// OpenFileInEditor opens filename in a text editor.
+func OpenFileInEditor(filename string) error {
+	editor := os.Getenv("EDITOR")
+	if editor == "" {
+		editor = DefaultEditor
+	}
+
+	// Get the full executable path for the editor.
+	executable, err := exec.LookPath(editor)
+	if err != nil {
+		return err
+	}
+
+	cmd := exec.Command(executable, filename)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	return cmd.Run()
+}
+
+// CaptureInputFromEditor opens a temporary file in a text editor and returns
+// the written bytes on success or an error on failure. It handles deletion
+// of the temporary file behind the scenes.
+func CaptureInputFromEditor() ([]byte, error) {
+	file, err := ioutil.TempFile(os.TempDir(), "*")
+	if err != nil {
+		return []byte{}, err
+	}
+
+	filename := file.Name()
+
+	// Defer removal of the temporary file in case any of the next steps fail.
+	defer os.Remove(filename)
+
+	if err = file.Close(); err != nil {
+		return []byte{}, err
+	}
+
+	if err = OpenFileInEditor(filename); err != nil {
+		return []byte{}, err
+	}
+
+	bytes, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return []byte{}, err
+	}
+
+	return bytes, nil
+}


### PR DESCRIPTION
potential improvement:
- the display and edit of topo are too tedious.
- use git diff style

example:
![Screen Shot 2020-03-31 at 9 18 22 PM](https://user-images.githubusercontent.com/1681864/78030868-59ac3200-7395-11ea-8db5-141cac39194a.png)
