### PR TITLE
*: various fixes and updates

### DIFF
--- a/cmd/import.go
+++ b/cmd/import.go
@@ -15,12 +15,14 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/fatih/color"
 	"github.com/pingcap-incubator/tiops/pkg/ansible"
 	"github.com/pingcap-incubator/tiops/pkg/log"
 	"github.com/pingcap-incubator/tiops/pkg/meta"
 	"github.com/pingcap-incubator/tiops/pkg/utils"
+	tiuplocaldata "github.com/pingcap-incubator/tiup/pkg/localdata"
 	"github.com/spf13/cobra"
 )
 
@@ -66,8 +68,14 @@ func newImportCmd() *cobra.Command {
 			// TODO: move original TiDB-Ansible directory to a staged location
 
 			log.Infof("Cluster %s imported.", clsName)
+
+			exeCmd := "tiops"
+			if os.Getenv(tiuplocaldata.EnvNameWorkDir) != "" {
+				exeCmd = "tiup cluster" // called by TiUP
+			}
+
 			fmt.Println(fmt.Sprintf("Try `%s` to see the cluster.",
-				color.HiYellowString("tiops display %s", clsName)))
+				color.HiYellowString("%s display %s", exeCmd, clsName)))
 			return nil
 		},
 	}

--- a/cmd/scale_in.go
+++ b/cmd/scale_in.go
@@ -44,7 +44,7 @@ func newScaleInCmd() *cobra.Command {
 			clusterName := args[0]
 			if !skipConfirm {
 				if err := cliutil.PromptForConfirmOrAbortError(
-					"This operation will delete the %s cluster nodes`%s` and delete those data.\nDo you want to continue? [y/N]:",
+					"This operation will delete the %s nodes in `%s` and all their data.\nDo you want to continue? [y/N]:",
 					strings.Join(options.Nodes, ","),
 					color.HiYellowString(clusterName)); err != nil {
 					return err

--- a/cmd/scale_out.go
+++ b/cmd/scale_out.go
@@ -125,6 +125,7 @@ func buildScaleOutTask(
 	metadata.Topology.IterInstance(func(instance meta.Instance) {
 		initializedHosts.Insert(instance.GetHost())
 	})
+	// uninitializedHosts are hosts which haven't been initialized yet
 	uninitializedHosts := set.NewStringSet()
 	newPart.IterInstance(func(instance meta.Instance) {
 		if host := instance.GetHost(); !initializedHosts.Exist(host) {

--- a/pkg/operation/action.go
+++ b/pkg/operation/action.go
@@ -501,7 +501,7 @@ func StopComponent(getter ExecutorGetter, instances []meta.Instance) error {
 
 		err = ins.WaitForDown(e)
 		if err != nil {
-			str := fmt.Sprintf("\t%s failed to stop: %s %s:%d",
+			str := fmt.Sprintf("\t%s %s:%d failed to stop: %s",
 				ins.ComponentName(),
 				ins.GetHost(),
 				ins.GetPort(),

--- a/pkg/operation/action.go
+++ b/pkg/operation/action.go
@@ -366,6 +366,7 @@ func StartComponent(getter ExecutorGetter, instances []meta.Instance) error {
 			Unit:         ins.ServiceName(),
 			ReloadDaemon: true,
 			Action:       "start",
+			Enabled:      true,
 		}
 		systemd := module.NewSystemdModule(c)
 		stdout, stderr, err := systemd.Execute(e)
@@ -448,8 +449,9 @@ func StopComponent(getter ExecutorGetter, instances []meta.Instance) error {
 
 		// Stop by systemd.
 		c := module.SystemdModuleConfig{
-			Unit:   ins.ServiceName(),
-			Action: "stop",
+			Unit:         ins.ServiceName(),
+			Action:       "stop",
+			ReloadDaemon: true, // always reload before operate
 			// Scope: "",
 		}
 		systemd := module.NewSystemdModule(c)

--- a/pkg/operation/action.go
+++ b/pkg/operation/action.go
@@ -374,7 +374,7 @@ func StartComponent(getter ExecutorGetter, instances []meta.Instance) error {
 		if len(stdout) > 0 {
 			fmt.Println(string(stdout))
 		}
-		if len(stderr) > 0 {
+		if len(stderr) > 0 && !bytes.Contains(stderr, []byte("Created symlink ")) {
 			log.Errorf(string(stderr))
 		}
 

--- a/pkg/operation/destroy.go
+++ b/pkg/operation/destroy.go
@@ -130,6 +130,9 @@ func DestroyComponent(getter ExecutorGetter, instances []meta.Instance) error {
 		// that later.
 		if !ins.IsImported() {
 			delPaths = append(delPaths, ins.DeployDir())
+			if logDir := ins.LogDir(); !strings.HasPrefix(ins.DeployDir(), logDir) {
+				delPaths = append(delPaths, logDir)
+			}
 		} else {
 			log.Warnf("Deploy dir %s not deleted for TiDB-Ansible imported instance %s.",
 				ins.DeployDir(), ins.InstanceName())

--- a/pkg/operation/destroy.go
+++ b/pkg/operation/destroy.go
@@ -119,8 +119,6 @@ func DestroyComponent(getter ExecutorGetter, instances []meta.Instance) error {
 		switch name {
 		case meta.ComponentTiKV, meta.ComponentPD, meta.ComponentPump, meta.ComponentDrainer, meta.ComponentPrometheus, meta.ComponentAlertManager:
 			delPaths = append(delPaths, ins.DataDir())
-			fallthrough
-		default:
 		}
 
 		// In TiDB-Ansible, deploy dir are shared by all components on the same

--- a/pkg/operation/destroy.go
+++ b/pkg/operation/destroy.go
@@ -121,7 +121,6 @@ func DestroyComponent(getter ExecutorGetter, instances []meta.Instance) error {
 			delPaths = append(delPaths, ins.DataDir())
 			fallthrough
 		default:
-			delPaths = append(delPaths, ins.LogDir())
 		}
 
 		// In TiDB-Ansible, deploy dir are shared by all components on the same
@@ -138,6 +137,7 @@ func DestroyComponent(getter ExecutorGetter, instances []meta.Instance) error {
 				ins.DeployDir(), ins.InstanceName())
 		}
 		delPaths = append(delPaths, fmt.Sprintf("/etc/systemd/system/%s", ins.ServiceName()))
+		log.Debugf("Deleting paths on %s: %s", ins.GetHost(), strings.Join(delPaths, " "))
 		c := module.ShellModuleConfig{
 			Command:  fmt.Sprintf("rm -rf %s;", strings.Join(delPaths, " ")),
 			Sudo:     true, // the .service files are in a directory owned by root

--- a/templates/config/alertmanager.yml
+++ b/templates/config/alertmanager.yml
@@ -1,65 +1,64 @@
-
 global:
-    # The smarthost and SMTP sender used for mail notifications.
-    smtp_smarthost: 'localhost:25'
-    smtp_from: 'alertmanager@example.org'
-    smtp_auth_username: 'alertmanager'
-    smtp_auth_password: 'password'
-    # smtp_require_tls: true
-  
-    # The Slack webhook URL.
-    # slack_api_url: ''
-  
-  route:
-    # A default receiver
-    receiver: "db-alert-email"
-  
-    # The labels by which incoming alerts are grouped together. For example,
-    # multiple alerts coming in for cluster=A and alertname=LatencyHigh would
-    # be batched into a single group.
-    group_by: ['env','instance','alertname','type','group','job']
-  
-    # When a new group of alerts is created by an incoming alert, wait at
-    # least 'group_wait' to send the initial notification.
-    # This way ensures that you get multiple alerts for the same group that start
-    # firing shortly after another are batched together on the first
-    # notification.
-    group_wait:      30s
-  
-    # When the first notification was sent, wait 'group_interval' to send a batch
-    # of new alerts that started firing for that group.
-    group_interval:  3m
-  
-    # If an alert has successfully been sent, wait 'repeat_interval' to
-    # resend them.
-    repeat_interval: 3m
-  
-    routes:
-    # - match:
-    #   receiver: webhook-kafka-adapter
-    #   continue: true
-    # - match:
-    #     env: test-cluster
-    #   receiver: db-alert-slack
-    # - match:
-    #     env: test-cluster
-    #   receiver: db-alert-email
-  
-  receivers:
-  # - name: 'webhook-kafka-adapter'
-  #   webhook_configs:
-  #   - send_resolved: true
-  #     url: 'http://10.0.3.6:28082/v1/alertmanager'
-  
-  #- name: 'db-alert-slack'
-  #  slack_configs:
-  #  - channel: '#alerts'
-  #    username: 'db-alert'
-  #    icon_emoji: ':bell:'
-  #    title:   '{{ .CommonLabels.alertname }}'
-  #    text:    '{{ .CommonAnnotations.summary }}  {{ .CommonAnnotations.description }}  expr: {{ .CommonLabels.expr }}  http://172.0.0.1:9093/#/alerts'
-  
-  - name: 'db-alert-email'
-    email_configs:
-    - send_resolved: true
-      to: 'xxx@xxx.com'
+  # The smarthost and SMTP sender used for mail notifications.
+  smtp_smarthost: 'localhost:25'
+  smtp_from: 'alertmanager@example.org'
+  smtp_auth_username: 'alertmanager'
+  smtp_auth_password: 'password'
+  # smtp_require_tls: true
+
+  # The Slack webhook URL.
+  # slack_api_url: ''
+
+route:
+  # A default receiver
+  receiver: "db-alert-email"
+
+  # The labels by which incoming alerts are grouped together. For example,
+  # multiple alerts coming in for cluster=A and alertname=LatencyHigh would
+  # be batched into a single group.
+  group_by: ['env','instance','alertname','type','group','job']
+
+  # When a new group of alerts is created by an incoming alert, wait at
+  # least 'group_wait' to send the initial notification.
+  # This way ensures that you get multiple alerts for the same group that start
+  # firing shortly after another are batched together on the first 
+  # notification.
+  group_wait:      30s
+
+  # When the first notification was sent, wait 'group_interval' to send a batch
+  # of new alerts that started firing for that group.
+  group_interval:  3m
+
+  # If an alert has successfully been sent, wait 'repeat_interval' to
+  # resend them.
+  repeat_interval: 3m
+
+  routes:
+  # - match:
+  #   receiver: webhook-kafka-adapter
+  #   continue: true
+  # - match:
+  #     env: test-cluster
+  #   receiver: db-alert-slack
+  # - match:
+  #     env: test-cluster
+  #   receiver: db-alert-email
+
+receivers:
+# - name: 'webhook-kafka-adapter'
+#   webhook_configs:
+#   - send_resolved: true
+#     url: 'http://10.0.3.6:28082/v1/alertmanager'
+
+#- name: 'db-alert-slack'
+#  slack_configs:
+#  - channel: '#alerts'
+#    username: 'db-alert'
+#    icon_emoji: ':bell:'
+#    title:   '{{ .CommonLabels.alertname }}'
+#    text:    '{{ .CommonAnnotations.summary }}  {{ .CommonAnnotations.description }}  expr: {{ .CommonLabels.expr }}  http://172.0.0.1:9093/#/alerts'
+
+- name: 'db-alert-email'
+  email_configs:
+  - send_resolved: true
+    to: 'xxx@xxx.com'


### PR DESCRIPTION
 - Always reload daemon (`systemctl daemon-reload`) before operations, if multiple instances are deployed on the same host, it may fail when trying to operate some of them
 - Properly exclude `log_dir` from deleting for imported instance
 - Set service to `enabled` when starting a service, and also handle the output of `systemctl enable`
 - Adjust outputs:
    - Show `tiup clsuter` instead of `tiops` when called by `tiup` in message after importing
    - Add a debug log listing paths to be deleted on destroying
    - Adjust start/stop outputs to show specific component and port
 - Replace the `alertmanager.yml` template from the one in TiDB-Ansible's repo, the former on is not compatible with current AlertManager and fails to start