### PR TITLE
Migrate SSH to use new error framework

### DIFF
--- a/pkg/ansible/dirs.go
+++ b/pkg/ansible/dirs.go
@@ -31,15 +31,12 @@ var (
 func parseDirs(host *aini.Host, ins meta.InstanceSpec) (meta.InstanceSpec, error) {
 	hostName, sshPort := ins.SSH()
 
-	e, err := executor.NewSSHExecutor(executor.SSHConfig{
+	e := executor.NewSSHExecutor(executor.SSHConfig{
 		Host:    hostName,
 		Port:    sshPort,
 		User:    host.Vars["ansible_user"],
 		KeyFile: SSHKeyPath(), // ansible generated keyfile
 	})
-	if err != nil {
-		return ins, err
-	}
 	log.Debugf("Detecting deploy paths on %s...", hostName)
 
 	switch ins.Role() {

--- a/pkg/cliutil/cliutil.go
+++ b/pkg/cliutil/cliutil.go
@@ -28,7 +28,7 @@ import (
 )
 
 var (
-	errNS             = errorx.NewNamespace("cli")
+	errNS             = errorx.NewNamespace("cliutil")
 	errMismatchArgs   = errNS.NewType("mismatch_args", errutil.ErrTraitPreCheck)
 	errOperationAbort = errNS.NewType("operation_aborted", errutil.ErrTraitPreCheck)
 )

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -13,7 +13,15 @@
 
 package executor
 
-import "time"
+import (
+	"time"
+
+	"github.com/joomcode/errorx"
+)
+
+var (
+	errNS = errorx.NewNamespace("executor")
+)
 
 // TiOpsExecutor is the executor interface for TiOps, all tasks will in the end
 // be passed to a executor and then be actually performed.

--- a/pkg/executor/ssh.go
+++ b/pkg/executor/ssh.go
@@ -118,8 +118,9 @@ func (e *SSHExecutor) Execute(cmd string, sudo bool, timeout ...time.Duration) (
 			WithProperty(ErrPropSSHStdout, stdout).
 			WithProperty(ErrPropSSHStderr, stderr)
 		if len(stdout) > 0 || len(stderr) > 0 {
+			output := strings.TrimSpace(strings.Join([]string{stdout, stderr}, "\n"))
 			baseErr = baseErr.
-				WithProperty(errutil.ErrPropSuggestion, fmt.Sprintf("Command output on remote host:\n%s", strings.Join([]string{stdout, stderr}, " ")))
+				WithProperty(errutil.ErrPropSuggestion, fmt.Sprintf("Command output on remote host:\n%s", output))
 		}
 		return []byte(stdout), []byte(stderr), baseErr
 	}

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -1,0 +1,20 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package meta
+
+import "github.com/joomcode/errorx"
+
+var (
+	errNS = errorx.NewNamespace("meta")
+)

--- a/pkg/module/module.go
+++ b/pkg/module/module.go
@@ -1,0 +1,7 @@
+package module
+
+import "github.com/joomcode/errorx"
+
+var (
+	errNS = errorx.NewNamespace("module")
+)

--- a/pkg/task/context.go
+++ b/pkg/task/context.go
@@ -27,12 +27,7 @@ func (ctx *Context) SetClusterSSH(topo *meta.Specification, deployUser string) e
 				User:    deployUser,
 			}
 
-			e, err := executor.NewSSHExecutor(cf)
-
-			if err != nil {
-				return errors.AddStack(err)
-			}
-
+			e := executor.NewSSHExecutor(cf)
 			ctx.SetExecutor(in.GetHost(), e)
 		}
 	}

--- a/pkg/task/env_init.go
+++ b/pkg/task/env_init.go
@@ -18,8 +18,15 @@ import (
 	"io/ioutil"
 	"strings"
 
+	"github.com/joomcode/errorx"
 	"github.com/pingcap-incubator/tiops/pkg/module"
-	"github.com/pingcap/errors"
+)
+
+var (
+	errNSEnvInit               = errNS.NewSubNamespace("env_init")
+	errEnvInitSubCommandFailed = errNSEnvInit.NewType("sub_command_failed")
+	// ErrEnvInitFailed is ErrEnvInitFailed
+	ErrEnvInitFailed = errNSEnvInit.NewType("failed")
 )
 
 // EnvInit is used to initialize the remote environment, e.g:
@@ -32,9 +39,17 @@ type EnvInit struct {
 
 // Execute implements the Task interface
 func (e *EnvInit) Execute(ctx *Context) error {
+	return e.execute(ctx)
+}
+
+func (e *EnvInit) execute(ctx *Context) error {
+	wrapError := func(err error) *errorx.Error {
+		return ErrEnvInitFailed.Wrap(err, "Failed to initialize TiDB environment on remote host '%s'", e.host)
+	}
+
 	exec, found := ctx.GetExecutor(e.host)
 	if !found {
-		return ErrNoExecutor
+		panic(ErrNoExecutor)
 	}
 
 	um := module.NewUserModule(module.UserModuleConfig{
@@ -43,21 +58,22 @@ func (e *EnvInit) Execute(ctx *Context) error {
 		Sudoer: true,
 	})
 
-	_, _, err := um.Execute(exec)
-	if err != nil {
-		return errors.Trace(err)
+	_, _, errx := um.Execute(exec)
+	if errx != nil {
+		return wrapError(errx)
 	}
 
 	pubKey, err := ioutil.ReadFile(ctx.PublicKeyPath)
 	if err != nil {
-		return errors.Trace(err)
+		return wrapError(err)
 	}
 
 	// Authorize
 	cmd := `su - ` + e.deployUser + ` -c 'test -d ~/.ssh || mkdir -p ~/.ssh && chmod 700 ~/.ssh'`
 	_, _, err = exec.Execute(cmd, true)
 	if err != nil {
-		return errors.Annotatef(err, "cmd: %s", cmd)
+		return wrapError(errEnvInitSubCommandFailed.
+			Wrap(err, "Failed to create '~/.ssh' directory for user '%s'", e.deployUser))
 	}
 
 	pk := strings.TrimSpace(string(pubKey))
@@ -65,7 +81,8 @@ func (e *EnvInit) Execute(ctx *Context) error {
 		e.deployUser, pk, "~/.ssh/authorized_keys")
 	_, _, err = exec.Execute(cmd, true)
 	if err != nil {
-		return errors.Trace(err)
+		return wrapError(errEnvInitSubCommandFailed.
+			Wrap(err, "Failed to write public keys to '~/.ssh/authorized_keys' for user '%s'", e.deployUser))
 	}
 
 	return nil

--- a/pkg/task/ssh.go
+++ b/pkg/task/ssh.go
@@ -16,8 +16,12 @@ package task
 import (
 	"fmt"
 
+	"github.com/joomcode/errorx"
 	"github.com/pingcap-incubator/tiops/pkg/executor"
-	"github.com/pingcap/errors"
+)
+
+var (
+	errNS = errorx.NewNamespace("task")
 )
 
 // RootSSH is used to establish a SSH connection to the target host with specific key
@@ -32,7 +36,7 @@ type RootSSH struct {
 
 // Execute implements the Task interface
 func (s *RootSSH) Execute(ctx *Context) error {
-	e, err := executor.NewSSHExecutor(executor.SSHConfig{
+	e := executor.NewSSHExecutor(executor.SSHConfig{
 		Host:       s.host,
 		Port:       s.port,
 		User:       s.user,
@@ -40,10 +44,6 @@ func (s *RootSSH) Execute(ctx *Context) error {
 		KeyFile:    s.keyFile,
 		Passphrase: s.passphrase,
 	})
-
-	if err != nil {
-		return errors.Trace(err)
-	}
 
 	ctx.SetExecutor(s.host, e)
 	return nil
@@ -73,15 +73,11 @@ type UserSSH struct {
 
 // Execute implements the Task interface
 func (s *UserSSH) Execute(ctx *Context) error {
-	e, err := executor.NewSSHExecutor(executor.SSHConfig{
+	e := executor.NewSSHExecutor(executor.SSHConfig{
 		Host:    s.host,
 		KeyFile: ctx.PrivateKeyPath,
 		User:    s.deployUser,
 	})
-
-	if err != nil {
-		return errors.Trace(err)
-	}
 
 	ctx.SetExecutor(s.host, e)
 	return nil

--- a/pkg/utils/cluster_name.go
+++ b/pkg/utils/cluster_name.go
@@ -1,0 +1,32 @@
+package utils
+
+import (
+	"regexp"
+
+	"github.com/joomcode/errorx"
+	"github.com/pingcap-incubator/tiops/pkg/errutil"
+)
+
+var (
+	// ErrInvalidClusterName is an error for invalid cluster name. You should use `ValidateClusterNameOrError()`
+	// to generate this error.
+	ErrInvalidClusterName = errorx.CommonErrors.NewType("invalid_cluster_name", errutil.ErrTraitPreCheck)
+)
+
+var (
+	clusterNameRegexp = regexp.MustCompile(`^[a-zA-Z0-9\-_]+$`)
+)
+
+// ValidateClusterNameOrError validates a cluster name and returns error if the name is invalid.
+func ValidateClusterNameOrError(n string) error {
+	if len(n) == 0 {
+		return ErrInvalidClusterName.
+			New("Cluster name must not be empty")
+	}
+	if !clusterNameRegexp.MatchString(n) {
+		return ErrInvalidClusterName.
+			New("Cluster name '%s' is invalid", n).
+			WithProperty(errutil.ErrPropSuggestion, "The cluster name should only contains alphabets, numbers, hyphen (-) and underscore (_).")
+	}
+	return nil
+}

--- a/pkg/utils/ioutils.go
+++ b/pkg/utils/ioutils.go
@@ -19,7 +19,7 @@ import (
 	"os"
 )
 
-// CreateDir creates the directory if it not alerady exist.
+// CreateDir creates the directory if it not exists.
 func CreateDir(path string) error {
 	if _, err := os.Stat(path); err != nil {
 		if os.IsNotExist(err) {

--- a/pkg/utils/topology.go
+++ b/pkg/utils/topology.go
@@ -3,7 +3,6 @@ package utils
 import (
 	"io/ioutil"
 
-	"github.com/joomcode/errorx"
 	"github.com/pingcap-incubator/tiops/pkg/cliutil"
 	"github.com/pingcap-incubator/tiops/pkg/errutil"
 	"go.uber.org/zap"
@@ -11,11 +10,11 @@ import (
 )
 
 var (
-	errTopologyNS = errorx.NewNamespace("topology")
+	errNSTopolohy = errNS.NewSubNamespace("topology")
 	// ErrTopologyReadFailed is ErrTopologyReadFailed
-	ErrTopologyReadFailed = errTopologyNS.NewType("read_failed", errutil.ErrTraitPreCheck)
+	ErrTopologyReadFailed = errNSTopolohy.NewType("read_failed", errutil.ErrTraitPreCheck)
 	// ErrTopologyParseFailed is ErrTopologyParseFailed
-	ErrTopologyParseFailed = errTopologyNS.NewType("parse_failed", errutil.ErrTraitPreCheck)
+	ErrTopologyParseFailed = errNSTopolohy.NewType("parse_failed", errutil.ErrTraitPreCheck)
 )
 
 // ParseTopologyYaml read yaml content from `file` and unmarshal it to `out`

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -19,6 +19,12 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/joomcode/errorx"
+)
+
+var (
+	errNS = errorx.NewNamespace("utils")
 )
 
 // JoinInt joins a slice of int to string


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1916485/78206694-20c5a780-74d2-11ea-8de0-047a17b68cd9.png)

Currently we cannot distinguish the SSH error (connection error, or execute command error, or other kind of errors), since all errors are generated by either `fmt.Errorf` or `errors`. Maybe we need to switch a SSH library, or manually match error strings? @lonng 