### PR TITLE
upgrade: remove store leader evicting scheduler after restart tikv

### DIFF
--- a/pkg/operation/upgrade.go
+++ b/pkg/operation/upgrade.go
@@ -89,6 +89,10 @@ func Upgrade(
 					if err := StartComponent(getter, []meta.Instance{instance}); err != nil {
 						return errors.Annotatef(err, "failed to start %s", component.Name())
 					}
+					// remove store leader evict scheduler after restart
+					if err := pdClient.RemoveStoreEvict(addr(instance)); err != nil {
+						return errors.Annotatef(err, "failed to remove evict store scheduler for %s", instance.GetHost())
+					}
 				}
 			}
 			continue


### PR DESCRIPTION
When doing rolling upgrading for TiKV nodes, we evict the leaders from the store of that node before restarting the process to minimize the impact of service. It is done by adding a leader evicting scheduler to that store.

However, we didin't remove the scheduler after restart, which result in the store will never get new leaders transferred to it again.

This PR add a new API to remove the leader evicting scheduler and call it after restarting the TiKV process. This is the same behavior TiDB-Ansible has.