### PR TITLE
Support errorx errors

### DIFF
--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -17,6 +17,7 @@ import (
 	"os"
 
 	"github.com/fatih/color"
+	"github.com/joomcode/errorx"
 	"github.com/pingcap-incubator/tiops/pkg/cliutil"
 	"github.com/pingcap-incubator/tiops/pkg/log"
 	"github.com/pingcap-incubator/tiops/pkg/logger"
@@ -69,8 +70,13 @@ func newDestroyCmd() *cobra.Command {
 				Build()
 
 			if err := t.Execute(task.NewContext()); err != nil {
-				return err
+				if errorx.Cast(err) != nil {
+					// FIXME: Map possible task errors and give suggestions.
+					return err
+				}
+				return errors.Trace(err)
 			}
+
 			if err := os.RemoveAll(meta.ClusterPath(clusterName)); err != nil {
 				return errors.Trace(err)
 			}

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -14,6 +14,7 @@
 package cmd
 
 import (
+	"github.com/joomcode/errorx"
 	"github.com/pingcap-incubator/tiops/pkg/logger"
 	"github.com/pingcap-incubator/tiops/pkg/meta"
 	"github.com/pingcap-incubator/tiops/pkg/task"
@@ -66,7 +67,15 @@ func newExecCmd() *cobra.Command {
 				ClusterSSH(metadata.Topology, metadata.User).
 				Parallel(shellTasks...).
 				Build()
-			return t.Execute(task.NewContext())
+
+			if err := t.Execute(task.NewContext()); err != nil {
+				if errorx.Cast(err) != nil {
+					// FIXME: Map possible task errors and give suggestions.
+					return err
+				}
+				return errors.Trace(err)
+			}
+			return nil
 		},
 	}
 

--- a/cmd/reload.go
+++ b/cmd/reload.go
@@ -17,6 +17,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/joomcode/errorx"
 	"github.com/pingcap-incubator/tiops/pkg/logger"
 	"github.com/pingcap-incubator/tiops/pkg/meta"
 	operator "github.com/pingcap-incubator/tiops/pkg/operation"
@@ -53,7 +54,15 @@ func newReloadCmd() *cobra.Command {
 				return err
 			}
 
-			return t.Execute(task.NewContext())
+			if err := t.Execute(task.NewContext()); err != nil {
+				if errorx.Cast(err) != nil {
+					// FIXME: Map possible task errors and give suggestions.
+					return err
+				}
+				return errors.Trace(err)
+			}
+
+			return nil
 		},
 	}
 

--- a/cmd/restart.go
+++ b/cmd/restart.go
@@ -14,6 +14,7 @@
 package cmd
 
 import (
+	"github.com/joomcode/errorx"
 	"github.com/pingcap-incubator/tiops/pkg/logger"
 	"github.com/pingcap-incubator/tiops/pkg/meta"
 	operator "github.com/pingcap-incubator/tiops/pkg/operation"
@@ -53,8 +54,15 @@ func newRestartCmd() *cobra.Command {
 				ClusterOperate(metadata.Topology, operator.RestartOperation, options).
 				Build()
 
-			return t.Execute(task.NewContext())
+			if err := t.Execute(task.NewContext()); err != nil {
+				if errorx.Cast(err) != nil {
+					// FIXME: Map possible task errors and give suggestions.
+					return err
+				}
+				return errors.Trace(err)
+			}
 
+			return nil
 		},
 	}
 

--- a/cmd/scale_in.go
+++ b/cmd/scale_in.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 
 	"github.com/fatih/color"
+	"github.com/joomcode/errorx"
 	"github.com/pingcap-incubator/tiops/pkg/cliutil"
 	"github.com/pingcap-incubator/tiops/pkg/log"
 	"github.com/pingcap-incubator/tiops/pkg/logger"
@@ -118,5 +119,13 @@ func scaleIn(clusterName string, options operator.Options) error {
 		Parallel(regenConfigTasks...).
 		Build()
 
-	return t.Execute(task.NewContext())
+	if err := t.Execute(task.NewContext()); err != nil {
+		if errorx.Cast(err) != nil {
+			// FIXME: Map possible task errors and give suggestions.
+			return err
+		}
+		return errors.Trace(err)
+	}
+
+	return nil
 }

--- a/cmd/scale_out.go
+++ b/cmd/scale_out.go
@@ -18,6 +18,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/joomcode/errorx"
 	"github.com/pingcap-incubator/tiops/pkg/bindversion"
 	"github.com/pingcap-incubator/tiops/pkg/cliutil"
 	"github.com/pingcap-incubator/tiops/pkg/executor"
@@ -130,7 +131,15 @@ func scaleOut(clusterName, topoFile string, opt scaleOutOptions) error {
 		return err
 	}
 
-	return t.Execute(task.NewContext())
+	if err := t.Execute(task.NewContext()); err != nil {
+		if errorx.Cast(err) != nil {
+			// FIXME: Map possible task errors and give suggestions.
+			return err
+		}
+		return errors.Trace(err)
+	}
+
+	return nil
 }
 
 func buildScaleOutTask(

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -14,6 +14,7 @@
 package cmd
 
 import (
+	"github.com/joomcode/errorx"
 	"github.com/pingcap-incubator/tiops/pkg/logger"
 	"github.com/pingcap-incubator/tiops/pkg/meta"
 	operator "github.com/pingcap-incubator/tiops/pkg/operation"
@@ -53,8 +54,15 @@ func newStartCmd() *cobra.Command {
 				ClusterOperate(metadata.Topology, operator.StartOperation, options).
 				Build()
 
-			return t.Execute(task.NewContext())
+			if err := t.Execute(task.NewContext()); err != nil {
+				if errorx.Cast(err) != nil {
+					// FIXME: Map possible task errors and give suggestions.
+					return err
+				}
+				return errors.Trace(err)
+			}
 
+			return nil
 		},
 	}
 

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -14,6 +14,7 @@
 package cmd
 
 import (
+	"github.com/joomcode/errorx"
 	"github.com/pingcap-incubator/tiops/pkg/logger"
 	"github.com/pingcap-incubator/tiops/pkg/meta"
 	operator "github.com/pingcap-incubator/tiops/pkg/operation"
@@ -52,8 +53,15 @@ func newStopCmd() *cobra.Command {
 				ClusterOperate(metadata.Topology, operator.StopOperation, options).
 				Build()
 
-			return t.Execute(task.NewContext())
+			if err := t.Execute(task.NewContext()); err != nil {
+				if errorx.Cast(err) != nil {
+					// FIXME: Map possible task errors and give suggestions.
+					return err
+				}
+				return errors.Trace(err)
+			}
 
+			return nil
 		},
 	}
 


### PR DESCRIPTION
Preserve errorx errors, while wrapping non errorx errors with `errors.Trace`.

Signed-off-by: Breezewish <me@breeswish.org>