### PR TITLE
adjust the result type of yaml unmarshal

### DIFF
--- a/pkg/meta/logic.go
+++ b/pkg/meta/logic.go
@@ -30,7 +30,6 @@ import (
 	system "github.com/pingcap-incubator/tiops/pkg/template/systemd"
 	"github.com/pingcap-incubator/tiup/pkg/set"
 	"github.com/pingcap/errors"
-	"gopkg.in/yaml.v2"
 )
 
 // Components names supported by TiOps
@@ -149,7 +148,7 @@ func (i *instance) InitConfig(e executor.TiOpsExecutor, cluster, user string, pa
 }
 
 // mergeServerConfig merges the server configuration and overwrite the global configuration
-func (i *instance) mergeServerConfig(e executor.TiOpsExecutor, globalConf, instanceConf yaml.MapSlice, paths DirPaths) error {
+func (i *instance) mergeServerConfig(e executor.TiOpsExecutor, globalConf, instanceConf map[string]interface{}, paths DirPaths) error {
 	fp := filepath.Join(paths.Cache, fmt.Sprintf("%s-%s-%d.toml", i.ComponentName(), i.GetHost(), i.GetPort()))
 	conf, err := merge2Toml(i.ComponentName(), globalConf, instanceConf)
 	if err != nil {

--- a/pkg/meta/topology.go
+++ b/pkg/meta/topology.go
@@ -26,7 +26,6 @@ import (
 	"github.com/pingcap-incubator/tiup/pkg/set"
 	"github.com/pingcap/errors"
 	pdserverapi "github.com/pingcap/pd/v4/server/api"
-	"gopkg.in/yaml.v2"
 )
 
 const (
@@ -69,11 +68,11 @@ type (
 
 	// ServerConfigs represents the server runtime configuration
 	ServerConfigs struct {
-		TiDB    yaml.MapSlice `yaml:"tidb"`
-		TiKV    yaml.MapSlice `yaml:"tikv"`
-		PD      yaml.MapSlice `yaml:"pd"`
-		Pump    yaml.MapSlice `yaml:"pump"`
-		Drainer yaml.MapSlice `yaml:"drainer"`
+		TiDB    map[string]interface{} `yaml:"tidb"`
+		TiKV    map[string]interface{} `yaml:"tikv"`
+		PD      map[string]interface{} `yaml:"pd"`
+		Pump    map[string]interface{} `yaml:"pump"`
+		Drainer map[string]interface{} `yaml:"drainer"`
 	}
 
 	// TopologySpecification represents the specification of topology.yaml
@@ -94,15 +93,15 @@ type (
 
 // TiDBSpec represents the TiDB topology specification in topology.yaml
 type TiDBSpec struct {
-	Host       string        `yaml:"host"`
-	SSHPort    int           `yaml:"ssh_port,omitempty"`
-	Imported   bool          `yaml:"imported,omitempty"`
-	Port       int           `yaml:"port" default:"4000"`
-	StatusPort int           `yaml:"status_port" default:"10080"`
-	DeployDir  string        `yaml:"deploy_dir,omitempty"`
-	LogDir     string        `yaml:"log_dir,omitempty"`
-	NumaNode   string        `yaml:"numa_node,omitempty"`
-	Config     yaml.MapSlice `yaml:"config,omitempty"`
+	Host       string                 `yaml:"host"`
+	SSHPort    int                    `yaml:"ssh_port,omitempty"`
+	Imported   bool                   `yaml:"imported,omitempty"`
+	Port       int                    `yaml:"port" default:"4000"`
+	StatusPort int                    `yaml:"status_port" default:"10080"`
+	DeployDir  string                 `yaml:"deploy_dir,omitempty"`
+	LogDir     string                 `yaml:"log_dir,omitempty"`
+	NumaNode   string                 `yaml:"numa_node,omitempty"`
+	Config     map[string]interface{} `yaml:"config,omitempty"`
 }
 
 // statusByURL queries current status of the instance by http status api.
@@ -149,17 +148,17 @@ func (s TiDBSpec) IsImported() bool {
 
 // TiKVSpec represents the TiKV topology specification in topology.yaml
 type TiKVSpec struct {
-	Host       string        `yaml:"host"`
-	SSHPort    int           `yaml:"ssh_port,omitempty"`
-	Imported   bool          `yaml:"imported,omitempty"`
-	Port       int           `yaml:"port" default:"20160"`
-	StatusPort int           `yaml:"status_port" default:"20180"`
-	DeployDir  string        `yaml:"deploy_dir,omitempty"`
-	DataDir    string        `yaml:"data_dir,omitempty"`
-	LogDir     string        `yaml:"log_dir,omitempty"`
-	Offline    bool          `yaml:"offline,omitempty"`
-	NumaNode   string        `yaml:"numa_node,omitempty"`
-	Config     yaml.MapSlice `yaml:"config,omitempty"`
+	Host       string                 `yaml:"host"`
+	SSHPort    int                    `yaml:"ssh_port,omitempty"`
+	Imported   bool                   `yaml:"imported,omitempty"`
+	Port       int                    `yaml:"port" default:"20160"`
+	StatusPort int                    `yaml:"status_port" default:"20180"`
+	DeployDir  string                 `yaml:"deploy_dir,omitempty"`
+	DataDir    string                 `yaml:"data_dir,omitempty"`
+	LogDir     string                 `yaml:"log_dir,omitempty"`
+	Offline    bool                   `yaml:"offline,omitempty"`
+	NumaNode   string                 `yaml:"numa_node,omitempty"`
+	Config     map[string]interface{} `yaml:"config,omitempty"`
 }
 
 // Status queries current status of the instance
@@ -221,14 +220,14 @@ type PDSpec struct {
 	SSHPort  int    `yaml:"ssh_port,omitempty"`
 	Imported bool   `yaml:"imported,omitempty"`
 	// Use Name to get the name with a default value if it's empty.
-	Name       string        `yaml:"name"`
-	ClientPort int           `yaml:"client_port" default:"2379"`
-	PeerPort   int           `yaml:"peer_port" default:"2380"`
-	DeployDir  string        `yaml:"deploy_dir,omitempty"`
-	DataDir    string        `yaml:"data_dir,omitempty"`
-	LogDir     string        `yaml:"log_dir,omitempty"`
-	NumaNode   string        `yaml:"numa_node,omitempty"`
-	Config     yaml.MapSlice `yaml:"config,omitempty"`
+	Name       string                 `yaml:"name"`
+	ClientPort int                    `yaml:"client_port" default:"2379"`
+	PeerPort   int                    `yaml:"peer_port" default:"2380"`
+	DeployDir  string                 `yaml:"deploy_dir,omitempty"`
+	DataDir    string                 `yaml:"data_dir,omitempty"`
+	LogDir     string                 `yaml:"log_dir,omitempty"`
+	NumaNode   string                 `yaml:"numa_node,omitempty"`
+	Config     map[string]interface{} `yaml:"config,omitempty"`
 }
 
 // Status queries current status of the instance
@@ -284,16 +283,16 @@ func (s PDSpec) IsImported() bool {
 
 // PumpSpec represents the Pump topology specification in topology.yaml
 type PumpSpec struct {
-	Host      string        `yaml:"host"`
-	SSHPort   int           `yaml:"ssh_port,omitempty"`
-	Imported  bool          `yaml:"imported,omitempty"`
-	Port      int           `yaml:"port" default:"8250"`
-	DeployDir string        `yaml:"deploy_dir,omitempty"`
-	DataDir   string        `yaml:"data_dir,omitempty"`
-	LogDir    string        `yaml:"log_dir,omitempty"`
-	Offline   bool          `yaml:"offline,omitempty"`
-	NumaNode  string        `yaml:"numa_node,omitempty"`
-	Config    yaml.MapSlice `yaml:"config,omitempty"`
+	Host      string                 `yaml:"host"`
+	SSHPort   int                    `yaml:"ssh_port,omitempty"`
+	Imported  bool                   `yaml:"imported,omitempty"`
+	Port      int                    `yaml:"port" default:"8250"`
+	DeployDir string                 `yaml:"deploy_dir,omitempty"`
+	DataDir   string                 `yaml:"data_dir,omitempty"`
+	LogDir    string                 `yaml:"log_dir,omitempty"`
+	Offline   bool                   `yaml:"offline,omitempty"`
+	NumaNode  string                 `yaml:"numa_node,omitempty"`
+	Config    map[string]interface{} `yaml:"config,omitempty"`
 }
 
 // Role returns the component role of the instance
@@ -318,17 +317,17 @@ func (s PumpSpec) IsImported() bool {
 
 // DrainerSpec represents the Drainer topology specification in topology.yaml
 type DrainerSpec struct {
-	Host      string        `yaml:"host"`
-	SSHPort   int           `yaml:"ssh_port,omitempty"`
-	Imported  bool          `yaml:"imported,omitempty"`
-	Port      int           `yaml:"port" default:"8249"`
-	DeployDir string        `yaml:"deploy_dir,omitempty"`
-	DataDir   string        `yaml:"data_dir,omitempty"`
-	LogDir    string        `yaml:"log_dir,omitempty"`
-	CommitTS  int64         `yaml:"commit_ts,omitempty"`
-	Offline   bool          `yaml:"offline,omitempty"`
-	NumaNode  string        `yaml:"numa_node,omitempty"`
-	Config    yaml.MapSlice `yaml:"config,omitempty"`
+	Host      string                 `yaml:"host"`
+	SSHPort   int                    `yaml:"ssh_port,omitempty"`
+	Imported  bool                   `yaml:"imported,omitempty"`
+	Port      int                    `yaml:"port" default:"8249"`
+	DeployDir string                 `yaml:"deploy_dir,omitempty"`
+	DataDir   string                 `yaml:"data_dir,omitempty"`
+	LogDir    string                 `yaml:"log_dir,omitempty"`
+	CommitTS  int64                  `yaml:"commit_ts,omitempty"`
+	Offline   bool                   `yaml:"offline,omitempty"`
+	NumaNode  string                 `yaml:"numa_node,omitempty"`
+	Config    map[string]interface{} `yaml:"config,omitempty"`
 }
 
 // Role returns the component role of the instance

--- a/pkg/meta/topology_test.go
+++ b/pkg/meta/topology_test.go
@@ -162,14 +162,7 @@ tidb_servers:
       log.file.rotate: "55555.xxx"
 `), &topo)
 	c.Assert(err, IsNil)
-	equal := func(ms yaml.MapSlice, expected map[string]interface{}) {
-		got := map[string]interface{}{}
-		for _, item := range ms {
-			got[item.Key.(string)] = item.Value
-		}
-		c.Assert(got, DeepEquals, expected)
-	}
-	equal(topo.ServerConfigs.TiDB, map[string]interface{}{
+	c.Assert(topo.ServerConfigs.TiDB, DeepEquals, map[string]interface{}{
 		"status.address":  10,
 		"port":            1230,
 		"latch.capacity":  20480,
@@ -189,7 +182,7 @@ tidb_servers:
 			},
 		},
 	}
-	got, err := toMap(topo.ServerConfigs.TiDB)
+	got, err := flattenMap(topo.ServerConfigs.TiDB)
 	c.Assert(err, IsNil)
 	c.Assert(got, DeepEquals, expected)
 	buf := &bytes.Buffer{}
@@ -218,7 +211,7 @@ tidb_servers:
 			},
 		},
 	}
-	got, err = toMap(topo.TiDBServers[0].Config)
+	got, err = flattenMap(topo.TiDBServers[0].Config)
 	c.Assert(err, IsNil)
 	c.Assert(got, DeepEquals, expected)
 
@@ -232,7 +225,7 @@ tidb_servers:
 			},
 		},
 	}
-	got, err = toMap(topo.TiDBServers[1].Config)
+	got, err = flattenMap(topo.TiDBServers[1].Config)
 	c.Assert(err, IsNil)
 	c.Assert(got, DeepEquals, expected)
 }
@@ -262,7 +255,7 @@ tikv_servers:
 			},
 		},
 	}
-	got, err := toMap(topo.TiKVServers[0].Config)
+	got, err := flattenMap(topo.TiKVServers[0].Config)
 	c.Assert(err, IsNil)
 	c.Assert(got, DeepEquals, expected)
 }
@@ -335,6 +328,12 @@ server_configs:
     schedule.replica-schedule-limit: 64
     schedule.merge-schedule-limit: 8
     schedule.hot-region-schedule-limit: 4
+    label-property:
+      reject-leader:
+        - key: "zone"
+          value: "cn1"
+        - key: "zone"
+          value: "cn1"
 
 tidb_servers:
   - host: 172.19.0.101
@@ -359,6 +358,16 @@ tikv_servers:
 #   pd:
 #     aa.b1.c3: value
 #     aa.b2.c4: value
+[label-property]
+
+[[label-property.reject-leader]]
+key = "zone"
+value = "cn1"
+
+[[label-property.reject-leader]]
+key = "zone"
+value = "cn1"
+
 [schedule]
 hot-region-schedule-limit = 14
 leader-schedule-limit = 4


### PR DESCRIPTION
Signed-off-by: Lonng <heng@lonng.org>

This PR tries to convert the `map[interface{}]interface{}` to `map[string]interface{}` to make it is possible to convert complex golang map to toml.