### PR TITLE
Ask for SSH identity passphrase on demand

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -22,13 +22,11 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/ScaleFT/sshkeys"
 	"github.com/fatih/color"
 	"github.com/joomcode/errorx"
 	"github.com/pingcap-incubator/tiops/pkg/bindversion"
 	"github.com/pingcap-incubator/tiops/pkg/cliutil"
 	"github.com/pingcap-incubator/tiops/pkg/errutil"
-	"github.com/pingcap-incubator/tiops/pkg/executor"
 	"github.com/pingcap-incubator/tiops/pkg/log"
 	"github.com/pingcap-incubator/tiops/pkg/logger"
 	"github.com/pingcap-incubator/tiops/pkg/meta"
@@ -40,7 +38,6 @@ import (
 	"github.com/pingcap/errors"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
-	"golang.org/x/crypto/ssh"
 )
 
 var (
@@ -56,12 +53,9 @@ type componentInfo struct {
 }
 
 type deployOptions struct {
-	user        string // username to login to the SSH server
-	usePasswd   bool   // use password for authentication
-	password    string // password of the user
-	keyFile     string // path to the private key file
-	passphrase  string // passphrase of the private key file
-	skipConfirm bool   // skip the confirmation of topology
+	user         string // username to login to the SSH server
+	identityFile string // path to the private key file
+	skipConfirm  bool   // skip the confirmation of topology
 }
 
 func newDeploy() *cobra.Command {
@@ -69,6 +63,7 @@ func newDeploy() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "deploy <cluster-name> <version> <topology.yaml>",
 		Short:        "Deploy a cluster for production",
+		Long:         "Deploy a cluster for production. SSH connection will be used to deploy files, as well as creating system users for running the service.",
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			shouldContinue, err := cliutil.CheckCommandArgsAndMayPrintHelp(cmd, args, 3)
@@ -79,49 +74,14 @@ func newDeploy() *cobra.Command {
 				return nil
 			}
 
-			if opt.usePasswd {
-				// FIXME: We should prompt for password when necessary automatically.
-				opt.password = cliutil.PromptForPassword("Password: ")
-				fmt.Println("")
-			}
-
-			// https://github.com/appleboy/easyssh-proxy/blob/7594a28d719d7da8767c7b024043b261ea15796c/easyssh.go#L96
-			// If this not a correct file path, it will ignore and just print a log to stdout.
-			// So we check here first.
-			if opt.keyFile != "" {
-				err = checkKey(opt.keyFile, opt.passphrase)
-				if err != nil {
-					return err
-				}
-			}
-
-			if len(opt.keyFile) == 0 && !opt.usePasswd {
-				// FIXME: We should lookup identity key automatically.
-				return executor.ErrSSHRequireCredential.
-					New("Identity file and password is unspecified").
-					WithProperty(cliutil.SuggestionFromTemplate(`
-You should specify either SSH identity file or password.
-
-To SSH connect using identity file:
-  {{ColorCommand}}{{OsArgs}} -i <file>{{ColorReset}}
-
-To SSH connect using password:
-  {{ColorCommand}}{{OsArgs}} --password{{ColorReset}}
-
-`, nil))
-			}
-
 			logger.EnableAuditLog()
 			return deploy(args[0], args[1], args[2], opt)
 		},
 	}
 
-	cmd.Flags().StringVar(&opt.user, "user", "root", "Specify the system user name")
-	cmd.Flags().BoolVar(&opt.usePasswd, "password", false, "Specify the password of system user")
-	cmd.Flags().StringVarP(&opt.keyFile, "identity_file", "i", "", "Specify the path of the SSH identity file")
-	// FIXME: We should prompt for passphrase automatically
-	cmd.Flags().StringVar(&opt.passphrase, "passphrase", "", "Specify the passphrase of the SSH identity file")
-	cmd.Flags().BoolVarP(&opt.skipConfirm, "yes", "y", false, "Skip the confirmation of topology")
+	cmd.Flags().StringVar(&opt.user, "user", "root", "The user name to login via SSH. The user must has root (or sudo) privilege.")
+	cmd.Flags().StringVarP(&opt.identityFile, "identity_file", "i", "", "The path of the SSH identity file. If specified, public key authentication will be used.")
+	cmd.Flags().BoolVarP(&opt.skipConfirm, "yes", "y", false, "Skip confirming the topology")
 
 	return cmd
 }
@@ -382,6 +342,11 @@ func deploy(clusterName, version, topoFile string, opt deployOptions) error {
 		}
 	}
 
+	sshConnProps, err := cliutil.ReadIdentityFileOrPassword(opt.identityFile)
+	if err != nil {
+		return err
+	}
+
 	if err := os.MkdirAll(meta.ClusterPath(clusterName), 0755); err != nil {
 		return errorx.InitializationFailed.
 			Wrap(err, "Failed to create cluster metadata directory '%s'", meta.ClusterPath(clusterName)).
@@ -400,7 +365,7 @@ func deploy(clusterName, version, topoFile string, opt deployOptions) error {
 		if !uniqueHosts.Exist(inst.GetHost()) {
 			uniqueHosts.Insert(inst.GetHost())
 			t := task.NewBuilder().
-				RootSSH(inst.GetHost(), inst.GetSSHPort(), opt.user, opt.password, opt.keyFile, opt.passphrase).
+				RootSSH(inst.GetHost(), inst.GetSSHPort(), opt.user, sshConnProps.Password, sshConnProps.IdentityFile, sshConnProps.IdentityFilePassphrase).
 				EnvInit(inst.GetHost(), topo.GlobalOptions.User).
 				UserSSH(inst.GetHost(), topo.GlobalOptions.User).
 				Build()
@@ -547,20 +512,4 @@ func buildMonitoredDeployTask(
 		}
 	}
 	return
-}
-
-func checkKey(keypath string, passphrase string) error {
-	var err error
-	buf, err := ioutil.ReadFile(keypath)
-	if err != nil {
-		return err
-	}
-
-	if passphrase != "" {
-		_, err = sshkeys.ParseEncryptedPrivateKey(buf, []byte(passphrase))
-	} else {
-		_, err = ssh.ParsePrivateKey(buf)
-	}
-
-	return err
 }

--- a/cmd/scale_out.go
+++ b/cmd/scale_out.go
@@ -14,14 +14,12 @@
 package cmd
 
 import (
-	"fmt"
 	"path/filepath"
 	"strings"
 
 	"github.com/joomcode/errorx"
 	"github.com/pingcap-incubator/tiops/pkg/bindversion"
 	"github.com/pingcap-incubator/tiops/pkg/cliutil"
-	"github.com/pingcap-incubator/tiops/pkg/executor"
 	"github.com/pingcap-incubator/tiops/pkg/logger"
 	"github.com/pingcap-incubator/tiops/pkg/meta"
 	operator "github.com/pingcap-incubator/tiops/pkg/operation"
@@ -33,15 +31,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var errPasswordKeyAtLeastOne = errors.New("--password and --key need to specify at least one")
-
 type scaleOutOptions struct {
-	user        string // username to login to the SSH server
-	usePasswd   bool   // use password for authentication
-	password    string // password of the user
-	keyFile     string // path to the private key file
-	passphrase  string // passphrase of the private key file
-	skipConfirm bool   // skip the confirmation of topology
+	user         string // username to login to the SSH server
+	identityFile string // path to the private key file
+	skipConfirm  bool   // skip the confirmation of topology
 }
 
 func newScaleOutCmd() *cobra.Command {
@@ -54,36 +47,15 @@ func newScaleOutCmd() *cobra.Command {
 			if len(args) != 2 {
 				return cmd.Help()
 			}
-			if opt.usePasswd {
-				opt.password = cliutil.PromptForPassword("Password: ")
-				fmt.Println("")
-			}
-			if len(opt.keyFile) == 0 && len(opt.password) == 0 {
-				// FIXME: We should lookup identity key automatically.
-				return executor.ErrSSHRequireCredential.
-					New("Identity file and password is unspecified").
-					WithProperty(cliutil.SuggestionFromTemplate(`
-You should specify either SSH identity file or password.
-
-To SSH connect using identity file:
-  {{ColorCommand}}{{OsArgs}} -i <file>{{ColorReset}}
-
-To SSH connect using password:
-  {{ColorCommand}}{{OsArgs}} --password{{ColorReset}}
-
-`, nil))
-			}
 
 			logger.EnableAuditLog()
 			return scaleOut(args[0], args[1], opt)
 		},
 	}
 
-	cmd.Flags().StringVar(&opt.user, "user", "root", "Specify the system user name")
-	cmd.Flags().BoolVar(&opt.usePasswd, "password", false, "Specify the password of system user")
-	cmd.Flags().StringVarP(&opt.keyFile, "identity_file", "i", "", "Specify the key path of system user")
-	cmd.Flags().StringVar(&opt.passphrase, "passphrase", "", "Specify the passphrase of the key")
-	cmd.Flags().BoolVarP(&opt.skipConfirm, "yes", "y", false, "Skip the confirmation of topology")
+	cmd.Flags().StringVar(&opt.user, "user", "root", "The user name to login via SSH. The user must has root (or sudo) privilege.")
+	cmd.Flags().StringVarP(&opt.identityFile, "identity_file", "i", "", "The path of the SSH identity file. If specified, public key authentication will be used.")
+	cmd.Flags().BoolVarP(&opt.skipConfirm, "yes", "y", false, "Skip confirming the topology")
 
 	return cmd
 }
@@ -127,8 +99,13 @@ func scaleOut(clusterName, topoFile string, opt scaleOutOptions) error {
 	newPart.MonitoredOptions = metadata.Topology.MonitoredOptions
 	newPart.ServerConfigs = metadata.Topology.ServerConfigs
 
+	sshConnProps, err := cliutil.ReadIdentityFileOrPassword(opt.identityFile)
+	if err != nil {
+		return err
+	}
+
 	// Build the scale out tasks
-	t, err := buildScaleOutTask(clusterName, metadata, mergedTopo, opt, &newPart)
+	t, err := buildScaleOutTask(clusterName, metadata, mergedTopo, opt, sshConnProps, &newPart)
 	if err != nil {
 		return err
 	}
@@ -149,6 +126,7 @@ func buildScaleOutTask(
 	metadata *meta.ClusterMeta,
 	mergedTopo *meta.Specification,
 	opt scaleOutOptions,
+	sshConnProps *cliutil.SSHConnectionProps,
 	newPart *meta.TopologySpecification) (task.Task, error) {
 	var (
 		envInitTasks       []task.Task // tasks which are used to initialize environment
@@ -168,7 +146,7 @@ func buildScaleOutTask(
 		if host := instance.GetHost(); !initializedHosts.Exist(host) {
 			uninitializedHosts.Insert(host)
 			t := task.NewBuilder().
-				RootSSH(instance.GetHost(), instance.GetSSHPort(), opt.user, opt.password, opt.keyFile, opt.passphrase).
+				RootSSH(instance.GetHost(), instance.GetSSHPort(), opt.user, sshConnProps.Password, sshConnProps.IdentityFile, sshConnProps.IdentityFilePassphrase).
 				EnvInit(instance.GetHost(), metadata.User).
 				Build()
 			envInitTasks = append(envInitTasks, t)

--- a/pkg/cliutil/ssh.go
+++ b/pkg/cliutil/ssh.go
@@ -24,7 +24,7 @@ type SSHConnectionProps struct {
 func ReadIdentityFileOrPassword(identityFilePath string) (*SSHConnectionProps, error) {
 	// If identity file is not specified, prompt to read password
 	if len(identityFilePath) == 0 {
-		password := PromptForPassword("The SSH password of the remote host: ")
+		password := PromptForPassword("Input SSH password: ")
 		return &SSHConnectionProps{
 			Password: password,
 		}, nil

--- a/pkg/cliutil/ssh.go
+++ b/pkg/cliutil/ssh.go
@@ -1,0 +1,75 @@
+package cliutil
+
+import (
+	"io/ioutil"
+
+	"github.com/ScaleFT/sshkeys"
+	"github.com/pingcap-incubator/tiops/pkg/errutil"
+	"golang.org/x/crypto/ssh"
+)
+
+var (
+	// ErrIdentityFileReadFiled is ErrIdentityFileReadFiled
+	ErrIdentityFileReadFiled = errNS.NewType("id_read_failed", errutil.ErrTraitPreCheck)
+)
+
+// SSHConnectionProps is SSHConnectionProps
+type SSHConnectionProps struct {
+	Password               string
+	IdentityFile           string
+	IdentityFilePassphrase string
+}
+
+// ReadIdentityFileOrPassword is ReadIdentityFileOrPassword
+func ReadIdentityFileOrPassword(identityFilePath string) (*SSHConnectionProps, error) {
+	// If identity file is not specified, prompt to read password
+	if len(identityFilePath) == 0 {
+		password := PromptForPassword("The SSH password of the remote host: ")
+		return &SSHConnectionProps{
+			Password: password,
+		}, nil
+	}
+
+	// Identity file is specified, check identity file
+	buf, err := ioutil.ReadFile(identityFilePath)
+	if err != nil {
+		return nil, ErrIdentityFileReadFiled.
+			Wrap(err, "Failed to read SSH identity file '%s'", identityFilePath).
+			WithProperty(SuggestionFromTemplate(`
+Please check whether your SSH identity file {{ColorKeyword}}{{.File}}{{ColorReset}} exists and have access permission.
+`, map[string]string{
+				"File": identityFilePath,
+			}))
+	}
+
+	// Try to decode as not encrypted
+	_, err = ssh.ParsePrivateKey(buf)
+	if err == nil {
+		return &SSHConnectionProps{
+			IdentityFile: identityFilePath,
+		}, nil
+	}
+
+	// Other kind of error.. e.g. not a valid SSH key
+	if _, ok := err.(*ssh.PassphraseMissingError); !ok {
+		return nil, ErrIdentityFileReadFiled.
+			Wrap(err, "Failed to read SSH identity file '%s'", identityFilePath).
+			WithProperty(SuggestionFromTemplate(`
+Looks like your SSH private key {{ColorKeyword}}{{.File}}{{ColorReset}} is invalid.
+`, map[string]string{
+				"File": identityFilePath,
+			}))
+	}
+
+	// SSH key is passphrase protected
+	passphrase := PromptForPassword("The SSH identity key is encrypted. Input its passphrase: ")
+	if _, err := sshkeys.ParseEncryptedPrivateKey(buf, []byte(passphrase)); err != nil {
+		return nil, ErrIdentityFileReadFiled.
+			Wrap(err, "Failed to decrypt SSH identity file '%s'", identityFilePath)
+	}
+
+	return &SSHConnectionProps{
+		IdentityFile:           identityFilePath,
+		IdentityFilePassphrase: passphrase,
+	}, nil
+}

--- a/pkg/cliutil/tui.go
+++ b/pkg/cliutil/tui.go
@@ -89,11 +89,11 @@ func PromptForConfirmOrAbortError(format string, a ...interface{}) error {
 
 // PromptForPassword reads a password input from console
 func PromptForPassword(format string, a ...interface{}) string {
-	defer fmt.Println("") // print a new line after reading input
-
 	fmt.Printf(format, a...)
 
-	input, err := terminal.ReadPassword(int(syscall.Stdin))
+	input, err := terminal.ReadPassword(syscall.Stdin)
+	fmt.Println("")
+
 	if err != nil {
 		return ""
 	}


### PR DESCRIPTION
When no parameters are specified, ask for password:

![image](https://user-images.githubusercontent.com/1916485/78238285-fd6d1d80-750e-11ea-92d3-3eca905993f0.png)

When identity key is provided, ask for passphrase if the identity key is encrypted. If the identity key is not encrypted, user will not be asked for a passphrase:
![image](https://user-images.githubusercontent.com/1916485/78238628-605eb480-750f-11ea-915c-e2367e53e2fe.png)

When identity key is invalid:
![image](https://user-images.githubusercontent.com/1916485/78238475-360cf700-750f-11ea-9c3e-b01084a8b4c6.png)

When identity key does not exist:
![image](https://user-images.githubusercontent.com/1916485/78238519-42914f80-750f-11ea-820b-100404130088.png)

When identity key decrypt failed:
![image](https://user-images.githubusercontent.com/1916485/78238591-55a41f80-750f-11ea-9730-2ff79b40b65a.png)

