### PR TITLE
Minor updates

### DIFF
--- a/cmd/import.go
+++ b/cmd/import.go
@@ -15,7 +15,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/fatih/color"
 	"github.com/pingcap-incubator/tiops/pkg/ansible"
@@ -23,7 +22,6 @@ import (
 	"github.com/pingcap-incubator/tiops/pkg/log"
 	"github.com/pingcap-incubator/tiops/pkg/meta"
 	"github.com/pingcap-incubator/tiops/pkg/utils"
-	tiuplocaldata "github.com/pingcap-incubator/tiup/pkg/localdata"
 	tiuputils "github.com/pingcap-incubator/tiup/pkg/utils"
 	"github.com/spf13/cobra"
 )
@@ -82,14 +80,8 @@ func newImportCmd() *cobra.Command {
 			// TODO: move original TiDB-Ansible directory to a staged location
 
 			log.Infof("Cluster %s imported.", clsName)
-
-			exeCmd := "tiops"
-			if os.Getenv(tiuplocaldata.EnvNameWorkDir) != "" {
-				exeCmd = "tiup cluster" // called by TiUP
-			}
-
 			fmt.Printf("Try `%s` to see the cluster.\n",
-				color.HiYellowString("%s display %s", exeCmd, clsName))
+				color.HiYellowString("%s display %s", cmd.Parent().Use, clsName))
 			return nil
 		},
 	}

--- a/pkg/executor/ssh.go
+++ b/pkg/executor/ssh.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/appleboy/easyssh-proxy"
+	"github.com/fatih/color"
 	"github.com/joomcode/errorx"
 	"github.com/pingcap-incubator/tiops/pkg/cliutil"
 	"github.com/pingcap-incubator/tiops/pkg/errutil"
@@ -121,7 +122,8 @@ func (e *SSHExecutor) Execute(cmd string, sudo bool, timeout ...time.Duration) (
 		if len(stdout) > 0 || len(stderr) > 0 {
 			output := strings.TrimSpace(strings.Join([]string{stdout, stderr}, "\n"))
 			baseErr = baseErr.
-				WithProperty(cliutil.SuggestionFromFormat("Command output on remote host:\n%s", output))
+				WithProperty(cliutil.SuggestionFromFormat("Command output on remote host:\n%s\n",
+					color.YellowString(output)))
 		}
 		return []byte(stdout), []byte(stderr), baseErr
 	}

--- a/pkg/executor/ssh.go
+++ b/pkg/executor/ssh.go
@@ -122,7 +122,8 @@ func (e *SSHExecutor) Execute(cmd string, sudo bool, timeout ...time.Duration) (
 		if len(stdout) > 0 || len(stderr) > 0 {
 			output := strings.TrimSpace(strings.Join([]string{stdout, stderr}, "\n"))
 			baseErr = baseErr.
-				WithProperty(cliutil.SuggestionFromFormat("Command output on remote host:\n%s\n",
+				WithProperty(cliutil.SuggestionFromFormat("Command output on remote host %s:\n%s\n",
+					e.Config.Server,
 					color.YellowString(output)))
 		}
 		return []byte(stdout), []byte(stderr), baseErr


### PR DESCRIPTION
1. Use root cmd's `Use` for information output

2. Set color for SSH output on error, make it more clear to read
    - Before:
![图片](https://user-images.githubusercontent.com/596538/78254840-11be1400-7529-11ea-88aa-1e5fabc37862.png)
    - After:
![图片](https://user-images.githubusercontent.com/596538/78254875-20a4c680-7529-11ea-8fa1-a8914dc9f968.png)
