### PR TITLE
Fix monitor path conflict

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -101,20 +101,20 @@ func checkClusterDirConflict(clusterName string, topo *meta.Specification) error
 		accessor func(meta.Instance, *meta.TopologySpecification) string
 	}
 
-	instanceDirAccessor := []DirAccessor {
+	instanceDirAccessor := []DirAccessor{
 		{dirKind: "deploy directory", accessor: func(instance meta.Instance, topo *meta.TopologySpecification) string { return instance.DeployDir() }},
 		{dirKind: "data directory", accessor: func(instance meta.Instance, topo *meta.TopologySpecification) string { return instance.DataDir() }},
 		{dirKind: "log directory", accessor: func(instance meta.Instance, topo *meta.TopologySpecification) string { return instance.LogDir() }},
 	}
-	hostDirAccessor := []DirAccessor {
+	hostDirAccessor := []DirAccessor{
 		{dirKind: "monitor deploy directory", accessor: func(instance meta.Instance, topo *meta.TopologySpecification) string {
-		return topo.MonitoredOptions.DeployDir
+			return topo.MonitoredOptions.DeployDir
 		}},
 		{dirKind: "monitor data directory", accessor: func(instance meta.Instance, topo *meta.TopologySpecification) string {
-		return topo.MonitoredOptions.DataDir
+			return topo.MonitoredOptions.DataDir
 		}},
 		{dirKind: "monitor log directory", accessor: func(instance meta.Instance, topo *meta.TopologySpecification) string {
-		return topo.MonitoredOptions.LogDir
+			return topo.MonitoredOptions.LogDir
 		}},
 	}
 
@@ -161,9 +161,9 @@ func checkClusterDirConflict(clusterName string, topo *meta.Specification) error
 			for _, dirAccessor := range hostDirAccessor {
 				existingEntries = append(existingEntries, Entry{
 					clusterName: fi.Name(),
-					dirKind:  dirAccessor.dirKind,
-					dir:      f(dirAccessor.accessor(inst, topo)),
-					instance: inst,
+					dirKind:     dirAccessor.dirKind,
+					dir:         f(dirAccessor.accessor(inst, topo)),
+					instance:    inst,
 				})
 			}
 		})

--- a/cmd/scale_out.go
+++ b/cmd/scale_out.go
@@ -82,10 +82,10 @@ func scaleOut(clusterName, topoFile string, opt scaleOutOptions) error {
 		return err
 	}
 
-	if err := checkClusterPortConflict(mergedTopo); err != nil {
+	if err := checkClusterPortConflict(clusterName, mergedTopo); err != nil {
 		return err
 	}
-	if err := checkClusterDirConflict(mergedTopo); err != nil {
+	if err := checkClusterDirConflict(clusterName, mergedTopo); err != nil {
 		return err
 	}
 

--- a/cmd/scale_out.go
+++ b/cmd/scale_out.go
@@ -76,10 +76,16 @@ func scaleOut(clusterName, topoFile string, opt scaleOutOptions) error {
 		return err
 	}
 
-	if err := checkClusterPortConflict(&newPart); err != nil {
+	// Abort scale out operation if the merged topology is invalid
+	mergedTopo := metadata.Topology.Merge(&newPart)
+	if err := mergedTopo.Validate(); err != nil {
 		return err
 	}
-	if err := checkClusterDirConflict(&newPart); err != nil {
+
+	if err := checkClusterPortConflict(mergedTopo); err != nil {
+		return err
+	}
+	if err := checkClusterDirConflict(mergedTopo); err != nil {
 		return err
 	}
 
@@ -87,12 +93,6 @@ func scaleOut(clusterName, topoFile string, opt scaleOutOptions) error {
 		if err := confirmTopology(clusterName, metadata.Version, &newPart); err != nil {
 			return err
 		}
-	}
-
-	// Abort scale out operation if the merged topology is invalid
-	mergedTopo := metadata.Topology.Merge(&newPart)
-	if err := mergedTopo.Validate(); err != nil {
-		return err
 	}
 
 	// Inherit existing global configuration

--- a/pkg/meta/logic.go
+++ b/pkg/meta/logic.go
@@ -862,6 +862,21 @@ func (topo *Specification) IterInstance(fn func(instance Instance)) {
 	}
 }
 
+// IterHost iterates one instance for each host
+func (topo *Specification) IterHost(fn func(instance Instance)) {
+	hostMap := make(map[string]bool)
+	for _, comp := range topo.ComponentsByStartOrder() {
+		for _, inst := range comp.Instances() {
+			host := inst.GetHost()
+			_, ok := hostMap[host]
+			if !ok {
+				hostMap[host] = true
+				fn(inst)
+			}
+		}
+	}
+}
+
 // Endpoints returns the PD endpoints configurations
 func (topo *Specification) Endpoints(user string) []*scripts.PDScript {
 	var ends []*scripts.PDScript


### PR DESCRIPTION
Fix #188

1. Check conflict with a merged topology 
2. Exclude instance with the same cluster name 
3. Iter host rather than iter instance for some Accessors