### PR TITLE
update topology unmarshal

### DIFF
--- a/pkg/utils/topology.go
+++ b/pkg/utils/topology.go
@@ -37,7 +37,7 @@ To generate a sample topology file:
 `, suggestionProps))
 	}
 
-	if err = yaml.Unmarshal(yamlFile, out); err != nil {
+	if err = yaml.UnmarshalStrict(yamlFile, out); err != nil {
 		return ErrTopologyParseFailed.
 			Wrap(err, "Failed to parse topology file %s", file).
 			WithProperty(cliutil.SuggestionFromTemplate(`


### PR DESCRIPTION
update topology unmarshal (strict mode)

It has been tested locally and the results are as follows.
```
Error: Failed to parse topology file ../topology.yaml (utils.topology.parse_failed)
  caused by: yaml: unmarshal errors:
  line 18: field monitoring_server not found in type meta.topology
  line 21: field grafana_server not found in type meta.topology

Please check the syntax of your topology file ../topology.yaml and try again.
```